### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@antelopejs/interface-api": "^0.0.2",
     "@antelopejs/interface-api-util": "^0.0.2",
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.3",
     "@antelopejs/interface-database": "^0.0.2",
     "@antelopejs/interface-database-decorators": "^0.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,6 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       '@antelopejs/interface-database':
         specifier: ^0.0.2
         version: 0.0.2
@@ -68,6 +68,9 @@ packages:
 
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@antelopejs/interface-database-decorators@0.0.2':
     resolution: {integrity: sha512-XWdk/L585gsKmKyP8XjsQuF2FlG+DScIEdPlE2Btg886CCxBSFZ+rKgVRmvEv5xZL1g8wq0MOEQIzFYCXasJOg==}
@@ -603,6 +606,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1408,6 +1414,10 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
+  '@antelopejs/interface-core@0.0.3':
+    dependencies:
+      reflect-metadata: 0.2.2
+
   '@antelopejs/interface-database-decorators@0.0.2':
     dependencies:
       '@antelopejs/interface-api': 0.0.2
@@ -1768,7 +1778,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1912,6 +1922,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -2014,7 +2026,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Remove wildcard subpath exports (`./*`) to hide internal dist paths from consumers
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This maintenance PR removes the wildcard `./*` subpath export from `package.json` to encapsulate internal dist paths, and bumps `@antelopejs/interface-core` from `^0.0.2` to `^0.0.3`. The lockfile is updated accordingly, including a transitive bump of `defu` from `6.1.4` to `6.1.7`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are intentional maintenance with one P2 note about the breaking-change nature of removing the wildcard export.

All findings are P2. The wildcard export removal is intentional and documented in the PR description; at `0.0.x` semver there is no stability guarantee. The dependency bump is minor and the lockfile is consistent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard `./*` subpath export (potentially breaking for consumers using direct subpath imports) and bumps `@antelopejs/interface-core` to `^0.0.3`. |
| pnpm-lock.yaml | Lockfile updated to reflect `@antelopejs/interface-core@0.0.3` and a transitive `defu` bump from `6.1.4` to `6.1.7`; all integrity hashes look well-formed. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer] -->|import '@antelopejs/interface-data-api'| B["exports['.'] → dist/index.js ✅"]
    A -->|import '@antelopejs/interface-data-api/package.json'| C["exports['./package.json'] ✅"]
    A -->|"import '@antelopejs/interface-data-api/some-submodule'"| D["exports['./*'] removed ❌"]
    D -->|after PR| E["ERR_PACKAGE_PATH_NOT_EXPORTED"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package.json
Line: 24-27

Comment:
**Removing `./*` is a breaking change for existing consumers**

Any downstream package currently importing a subpath (e.g. `import ... from '@antelopejs/interface-data-api/some-module'`) will start receiving a `Package subpath './some-module' is not defined by "exports"` error after this change. At `0.0.x` semver does not guarantee stability, but if any internal or external consumers rely on these subpath imports today they will break silently on install. Consider verifying no consumers use these paths, or documenting the breaking change in the release notes.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-data-api/commit/4c1095adba7893776ed2155a39f679f61cbcc977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29166819)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->