### PR TITLE
feat: add Joined field decorator for native cross-table flattening

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -7,13 +7,6 @@ export default defineConfig({
   name: "interface-data-api-test",
   cacheFolder: ".antelope/cache",
   modules: {
-    "data-api": {
-      source: {
-        type: "package",
-        package: "@antelopejs/data-api",
-        version: "1.0.0",
-      },
-    },
     mongodb: {
       source: {
         type: "package",

--- a/src/components.ts
+++ b/src/components.ts
@@ -359,15 +359,24 @@ export namespace Query {
 
     type RowShape = Record<string, unknown>;
     const emptyRemote: RowShape = {};
+    const tmpKeyFor = (localKey: string) => `__joined_orig_${localKey}`;
 
     if (query instanceof Stream) {
       let stream: Stream<RowShape> = query as Stream<RowShape>;
+      const tmpKeys: string[] = [];
       for (const group of groups) {
         const remoteFields = group.fields.map((f) => f.remoteField);
         const remoteTable = db
           .table(group.table)
-          .pluck("_internal", group.remoteIndex, ...remoteFields) as Table<RowShape>;
+          .pluck(
+            "_internal",
+            group.remoteIndex,
+            ...remoteFields,
+          ) as Table<RowShape>;
+        const tmpKey = tmpKeyFor(group.localKey);
+        tmpKeys.push(tmpKey);
         stream = stream
+          .map((row) => row.merge({ [tmpKey]: row.key(group.localKey) }))
           .lookup(remoteTable, group.localKey, group.remoteIndex)
           .map((row) => {
             const merged: RowShape = {};
@@ -375,11 +384,11 @@ export namespace Query {
             for (const f of group.fields) {
               merged[f.name] = remote.key(f.remoteField).default(null);
             }
-            merged[group.localKey] = remote.key(group.remoteIndex).default(null);
+            merged[group.localKey] = row.key(tmpKey);
             return row.merge(merged);
           }) as Stream<RowShape>;
       }
-      return stream;
+      return stream.without(...tmpKeys) as Stream<RowShape>;
     }
 
     let datum: Datum<RowShape> = query as Datum<RowShape>;
@@ -387,8 +396,14 @@ export namespace Query {
       const remoteFields = group.fields.map((f) => f.remoteField);
       const remoteTable = db
         .table(group.table)
-        .pluck("_internal", group.remoteIndex, ...remoteFields) as Table<RowShape>;
+        .pluck(
+          "_internal",
+          group.remoteIndex,
+          ...remoteFields,
+        ) as Table<RowShape>;
+      const tmpKey = tmpKeyFor(group.localKey);
       datum = datum
+        .do((row) => row.merge({ [tmpKey]: row.key(group.localKey) }))
         .lookup(remoteTable, group.localKey, group.remoteIndex)
         .do((row) => {
           const merged: RowShape = {};
@@ -396,7 +411,7 @@ export namespace Query {
           for (const f of group.fields) {
             merged[f.name] = remote.key(f.remoteField).default(null);
           }
-          merged[group.localKey] = remote.key(group.remoteIndex).default(null);
+          merged[group.localKey] = row.key(tmpKey);
           return row.merge(merged);
         }) as Datum<RowShape>;
     }

--- a/src/components.ts
+++ b/src/components.ts
@@ -309,6 +309,100 @@ export namespace Query {
     }
   }
 
+  interface JoinedGroup {
+    table: string;
+    localKey: string;
+    remoteIndex: string;
+    fields: Array<{ name: string; remoteField: string }>;
+  }
+
+  function collectJoinedGroups(meta: DataAPIMeta): JoinedGroup[] {
+    const groups = new Map<string, JoinedGroup>();
+    for (const [name, field] of Object.entries(meta.fields)) {
+      if (!field.joined) continue;
+      const j = field.joined;
+      const groupKey = `${j.table}|${j.localKey}|${j.remoteIndex}`;
+      let group = groups.get(groupKey);
+      if (!group) {
+        group = {
+          table: j.table,
+          localKey: j.localKey,
+          remoteIndex: j.remoteIndex,
+          fields: [],
+        };
+        groups.set(groupKey, group);
+      }
+      group.fields.push({ name, remoteField: j.remoteField });
+    }
+    return Array.from(groups.values());
+  }
+
+  export function Joined(
+    db: SchemaInstance<any>,
+    meta: DataAPIMeta,
+    query: Stream<any>,
+  ): Stream<any>;
+  export function Joined(
+    db: SchemaInstance<any>,
+    meta: DataAPIMeta,
+    query: Datum<any>,
+  ): Datum<any>;
+  export function Joined(
+    db: SchemaInstance<any>,
+    meta: DataAPIMeta,
+    query: Stream<any> | Datum<any>,
+  ): Stream<any> | Datum<any> {
+    const groups = collectJoinedGroups(meta);
+    if (groups.length === 0) {
+      return query as any;
+    }
+
+    type RowShape = Record<string, unknown>;
+    const emptyRemote: RowShape = {};
+
+    if (query instanceof Stream) {
+      let stream: Stream<RowShape> = query as Stream<RowShape>;
+      for (const group of groups) {
+        const remoteFields = group.fields.map((f) => f.remoteField);
+        const remoteTable = db
+          .table(group.table)
+          .pluck("_internal", group.remoteIndex, ...remoteFields) as Table<RowShape>;
+        stream = stream
+          .lookup(remoteTable, group.localKey, group.remoteIndex)
+          .map((row) => {
+            const merged: RowShape = {};
+            const remote = row.key(group.localKey).default(emptyRemote);
+            for (const f of group.fields) {
+              merged[f.name] = remote.key(f.remoteField).default(null);
+            }
+            merged[group.localKey] = remote.key(group.remoteIndex).default(null);
+            return row.merge(merged);
+          }) as Stream<RowShape>;
+      }
+      return stream;
+    }
+
+    let datum: Datum<RowShape> = query as Datum<RowShape>;
+    for (const group of groups) {
+      const remoteFields = group.fields.map((f) => f.remoteField);
+      const remoteTable = db
+        .table(group.table)
+        .pluck("_internal", group.remoteIndex, ...remoteFields) as Table<RowShape>;
+      datum = datum
+        .lookup(remoteTable, group.localKey, group.remoteIndex)
+        .do((row) => {
+          const merged: RowShape = {};
+          const remote = row.key(group.localKey).default(emptyRemote);
+          for (const f of group.fields) {
+            merged[f.name] = remote.key(f.remoteField).default(null);
+          }
+          merged[group.localKey] = remote.key(group.remoteIndex).default(null);
+          return row.merge(merged);
+        }) as Datum<RowShape>;
+    }
+    return datum;
+  }
+
   export async function ReadProperties(
     obj: any,
     meta: DataAPIMeta,
@@ -390,6 +484,7 @@ export namespace Query {
     reqCtx: RequestContext,
     sorting?: [string, "asc" | "desc" | undefined],
     filters?: Record<string, FilterValue>,
+    db?: SchemaInstance<any>,
   ): [sorted: Stream<T>, total: Datum<number>] {
     const filterList = Object.entries(meta.filters).filter(
       ([name]) => filters && name in filters,
@@ -402,9 +497,13 @@ export namespace Query {
       : undefined;
     const indexedFilter = indexFilter ? filters?.[indexFilter] : undefined;
 
-    let tmpRequest = index
+    let tmpRequest: Stream<T> = index
       ? request.getAll(indexedFilter?.[0] ?? "", index)
       : request;
+
+    if (db) {
+      tmpRequest = Joined(db, meta, tmpRequest as Stream<any>) as Stream<T>;
+    }
 
     const sortField = sorting?.[0];
     const shouldSort = sortField ? meta.fields[sortField]?.sortable : undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,8 @@ export namespace DefaultRoutes {
       const model = Query.GetModel(this, meta);
       let query = Query.Get(model.table, params.id, params.index);
 
+      query = Query.Joined(model.database, meta, query);
+
       if (!params.noForeign) {
         query = Query.Foreign(model.database, meta, query);
       }
@@ -180,6 +182,7 @@ export namespace DefaultRoutes {
         reqCtx,
         sort,
         params?.filters,
+        model.database,
       );
 
       const pluck: Set<string> | undefined =

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -75,6 +75,20 @@ export interface FieldData {
   ];
 
   /**
+   * Joined-from-other-table reference.
+   *
+   * Imports a single scalar field from another table at query time and
+   * flattens it into the row, enabling sort/search/filter natively in DB.
+   */
+  joined?: {
+    table: string;
+    tableClass?: Class<Table>;
+    localKey: string;
+    remoteField: string;
+    remoteIndex: string;
+  };
+
+  /**
    * Value validator callback.
    */
   validator?: (value: unknown) => boolean | Promise<boolean>;
@@ -313,12 +327,16 @@ export class DataAPIMeta {
     mode = "list",
   ) {
     const field = this.field(name);
-    const names =
+    const baseNames =
       typeof requiredFields === "boolean"
         ? requiredFields
           ? [name]
           : []
         : requiredFields;
+    const names =
+      baseNames.length > 0 && field.joined
+        ? Array.from(new Set([...baseNames, name, field.joined.localKey]))
+        : baseNames;
     if (!field.listable) {
       field.listable = {};
     }
@@ -347,7 +365,82 @@ export class DataAPIMeta {
    * @returns
    */
   public setSortable(name: string, active: boolean, noIndex?: boolean) {
-    this.field(name).sortable = active ? { indexed: !noIndex } : undefined;
+    const field = this.field(name);
+    if (!active) {
+      field.sortable = undefined;
+      return this;
+    }
+    field.sortable = { indexed: !noIndex && !field.joined };
+    return this;
+  }
+
+  /**
+   * Declares a field to be a flat join from another table.
+   *
+   * The value is read-only (set by lookup at query time, not persisted on this table).
+   * The field becomes natively sortable/searchable/filterable since the join
+   * is applied to the underlying query before sorting/filtering.
+   *
+   * @param name Field name
+   * @param options Joined options (other table, local key, remote field, remote index)
+   */
+  public setJoined(
+    name: string,
+    options: {
+      table: string | Class<Table>;
+      localKey: string;
+      remoteField: string;
+      remoteIndex?: string;
+    },
+  ) {
+    const databaseSchema = getTablesForSchema(this.schemaName);
+    if (!databaseSchema)
+      throw new Error(`Schema "${this.schemaName}" not found`);
+
+    let tableName: string;
+    let tableClass: Class<Table> | undefined;
+    if (typeof options.table === "string") {
+      tableName = options.table;
+      tableClass = databaseSchema[options.table];
+    } else {
+      const found = Object.entries(databaseSchema).find(
+        ([, table_]) => table_ === options.table,
+      );
+      if (!found) {
+        throw new Error(
+          `Unable to infer joined table name for field "${name}"`,
+        );
+      }
+      tableName = found[0];
+      tableClass = options.table;
+    }
+
+    const field = this.field(name);
+    field.joined = {
+      table: tableName,
+      tableClass,
+      localKey: options.localKey,
+      remoteField: options.remoteField,
+      remoteIndex: options.remoteIndex ?? "_id",
+    };
+
+    field.mode = AccessMode.ReadOnly;
+
+    if (field.sortable?.indexed) {
+      field.sortable = { indexed: false };
+    }
+
+    if (field.listable) {
+      for (const mode of Object.keys(field.listable)) {
+        if (field.listable[mode].length === 0) continue;
+        field.listable[mode] = Array.from(
+          new Set([...field.listable[mode], name, field.joined.localKey]),
+        );
+      }
+      this.recomputeListable();
+    }
+
+    this.recomputeAccess();
     return this;
   }
 
@@ -565,6 +658,34 @@ export const Sortable = MakeMethodAndPropertyDecorator(
     GetMetadata(target.constructor, DataAPIMeta)
       .setDescriptor(key as string, desc)
       .setSortable(key as string, true, options?.noIndex ?? false);
+  },
+);
+
+/**
+ * Declares a field whose value is imported (flattened) from another table.
+ *
+ * The local row carries a foreign key (`localKey`); the framework adds a
+ * lookup so the remote field appears at the top level of each row before
+ * filters and sorting are applied. This makes the field natively sortable,
+ * filterable, and searchable in DB.
+ *
+ * Joined fields are auto read-only and forced to non-indexed sort.
+ */
+export const Joined = MakePropertyDecorator(
+  (
+    target,
+    key,
+    options: {
+      table: string | Class<Table>;
+      localKey: string;
+      remoteField: string;
+      remoteIndex?: string;
+    },
+  ) => {
+    GetMetadata(target.constructor, DataAPIMeta).setJoined(
+      key as string,
+      options,
+    );
   },
 );
 

--- a/src/tests/components/joined.test.ts
+++ b/src/tests/components/joined.test.ts
@@ -265,6 +265,7 @@ async function returnsNullForOrphanForeignKey() {
   expect(orphan).to.not.equal(undefined);
   expect(orphan?.name).to.equal(null);
   expect(orphan?.email).to.equal(null);
+  expect(orphan?.authorId).to.equal(orphanAuthorId);
 }
 
 async function ignoresJoinedFieldOnEdit() {

--- a/src/tests/components/joined.test.ts
+++ b/src/tests/components/joined.test.ts
@@ -1,0 +1,290 @@
+import path from "node:path";
+import { Controller } from "@antelopejs/interface-api";
+import {
+  DataController,
+  DefaultRoutes,
+  RegisterDataController,
+} from "@antelopejs/interface-data-api";
+import {
+  Access,
+  AccessMode,
+  Filter,
+  Joined,
+  Listable,
+  ModelReference,
+  Sortable,
+} from "@antelopejs/interface-data-api/metadata";
+import { Schema } from "@antelopejs/interface-database";
+import {
+  BasicDataModel,
+  CreateDatabaseSchemaInstance,
+  Model,
+  RegisterTable,
+  Table,
+} from "@antelopejs/interface-database-decorators";
+import { expect } from "chai";
+import {
+  editRequest,
+  getFunctionName,
+  getRequest,
+  getSchemaInstance,
+  listRequest,
+} from "../utils";
+
+const currentTestName = path
+  .basename(__filename)
+  .replace(/\.test\.(ts|js)$/, "");
+const authorTableName = `authors-${currentTestName}`;
+const bookTableName = `books-${currentTestName}`;
+const schemaName = "default";
+
+@RegisterTable(authorTableName, schemaName)
+class Author extends Table {
+  declare _id: string;
+  declare name: string;
+  declare email: string;
+}
+class AuthorModel extends BasicDataModel(Author, authorTableName) {}
+
+@RegisterTable(bookTableName, schemaName)
+class Book extends Table {
+  declare _id: string;
+  declare authorId: string;
+  declare title: string;
+  declare price: number;
+}
+class BookModel extends BasicDataModel(Book, bookTableName) {}
+
+interface BookListed {
+  _id: string;
+  authorId: string;
+  title: string;
+  price: number;
+  name: string | null;
+  email: string | null;
+}
+
+const authorsDataset: Partial<Author>[] = [
+  { name: "Alice Carter", email: "alice@example.com" },
+  { name: "Bob Stone", email: "bob@example.com" },
+  { name: "Carol Wilde", email: "carol@example.com" },
+];
+
+const orphanAuthorId = "orphan-author-id";
+
+describe("Field Joined", () => {
+  it("lists rows with joined fields flattened", async () =>
+    await listsRowsWithJoinedFieldsFlattened());
+  it("gets row with joined fields flattened", async () =>
+    await getsRowWithJoinedFieldsFlattened());
+  it("sorts by joined field ascending", async () =>
+    await sortsByJoinedFieldAscending());
+  it("sorts by joined field descending", async () =>
+    await sortsByJoinedFieldDescending());
+  it("filters by joined field", async () => await filtersByJoinedField());
+  it("returns null for orphan foreign key", async () =>
+    await returnsNullForOrphanForeignKey());
+  it("ignores joined field on edit body", async () =>
+    await ignoresJoinedFieldOnEdit());
+});
+
+async function _createDataController(testName: string) {
+  @RegisterDataController()
+  class _JoinedTestAPI extends DataController(
+    Book,
+    {
+      list: DefaultRoutes.List,
+      get: DefaultRoutes.Get,
+      edit: DefaultRoutes.Edit,
+    },
+    Controller(`/${testName}`),
+  ) {
+    @ModelReference()
+    @Model(BookModel)
+    declare bookModel: BookModel;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare _id: string;
+
+    @Listable()
+    @Access(AccessMode.ReadWrite)
+    declare authorId: string;
+
+    @Listable()
+    @Access(AccessMode.ReadWrite)
+    @Sortable({ noIndex: true })
+    declare title: string;
+
+    @Listable()
+    @Access(AccessMode.ReadWrite)
+    @Sortable({ noIndex: true })
+    declare price: number;
+
+    @Listable(["authorId"])
+    @Joined({
+      table: authorTableName,
+      localKey: "authorId",
+      remoteField: "name",
+    })
+    @Sortable({ noIndex: true })
+    @Filter()
+    declare name: string;
+
+    @Listable(["authorId"])
+    @Joined({
+      table: authorTableName,
+      localKey: "authorId",
+      remoteField: "email",
+    })
+    declare email: string;
+  }
+
+  await CreateDatabaseSchemaInstance(schemaName);
+  await _dropTables();
+
+  const schemaInstance = getSchemaInstance(schemaName);
+  const authorModel = new AuthorModel(schemaInstance);
+  const bookModel = new BookModel(schemaInstance);
+
+  const authorIdsRecord = await authorModel.insert(authorsDataset);
+  const authorIds = Object.values(authorIdsRecord);
+
+  const booksDataset: Partial<Book>[] = [
+    { authorId: authorIds[0], title: "Alpha Rising", price: 19.99 },
+    { authorId: authorIds[1], title: "Beta Stories", price: 29.99 },
+    { authorId: authorIds[2], title: "Gamma Tales", price: 9.99 },
+    { authorId: authorIds[0], title: "Alpha Returns", price: 24.99 },
+    { authorId: orphanAuthorId, title: "Lost Chapter", price: 4.99 },
+  ];
+
+  const bookIdsRecord = await bookModel.insert(booksDataset);
+  const bookIds = Object.values(bookIdsRecord);
+
+  return { authorIds, bookIds, authorModel, bookModel };
+}
+
+async function _dropTables() {
+  const schema = Schema.get(schemaName);
+  if (schema) {
+    await schema.instance().table(bookTableName).delete();
+    await schema.instance().table(authorTableName).delete();
+  }
+}
+
+async function listsRowsWithJoinedFieldsFlattened() {
+  await _createDataController(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {});
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: BookListed[] };
+  expect(data.results).to.have.lengthOf(5);
+
+  const alphaRising = data.results.find((b) => b.title === "Alpha Rising");
+  expect(alphaRising).to.not.equal(undefined);
+  expect(alphaRising?.name).to.equal("Alice Carter");
+  expect(alphaRising?.email).to.equal("alice@example.com");
+  expect(typeof alphaRising?.authorId).to.equal("string");
+
+  const betaStories = data.results.find((b) => b.title === "Beta Stories");
+  expect(betaStories?.name).to.equal("Bob Stone");
+  expect(betaStories?.email).to.equal("bob@example.com");
+}
+
+async function getsRowWithJoinedFieldsFlattened() {
+  const { bookIds } = await _createDataController(getFunctionName());
+
+  const response = await getRequest(getFunctionName(), { id: bookIds[0] });
+  if (response.status !== 200) {
+    const text = await response.text();
+    throw new Error(`get failed (${response.status}): ${text}`);
+  }
+  const book = (await response.json()) as BookListed;
+  expect(book.title).to.equal("Alpha Rising");
+  expect(book.name).to.equal("Alice Carter");
+  expect(book.email).to.equal("alice@example.com");
+  expect(typeof book.authorId).to.equal("string");
+}
+
+async function sortsByJoinedFieldAscending() {
+  await _createDataController(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {
+    sortKey: "name",
+    sortDirection: "asc",
+  });
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: BookListed[] };
+  const namesInOrder = data.results
+    .map((b) => b.name)
+    .filter((n): n is string => typeof n === "string");
+  const sorted = [...namesInOrder].sort((a, b) => a.localeCompare(b));
+  expect(namesInOrder).to.deep.equal(sorted);
+}
+
+async function sortsByJoinedFieldDescending() {
+  await _createDataController(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {
+    sortKey: "name",
+    sortDirection: "desc",
+  });
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: BookListed[] };
+  const namesInOrder = data.results
+    .map((b) => b.name)
+    .filter((n): n is string => typeof n === "string");
+  const sorted = [...namesInOrder].sort((a, b) => b.localeCompare(a));
+  expect(namesInOrder).to.deep.equal(sorted);
+}
+
+async function filtersByJoinedField() {
+  await _createDataController(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {
+    filter_name: "eq:Alice Carter",
+  });
+  if (response.status !== 200) {
+    const text = await response.text();
+    throw new Error(`filter failed (${response.status}): ${text}`);
+  }
+  const data = (await response.json()) as { results: BookListed[] };
+  expect(data.results.length).to.equal(2);
+  for (const book of data.results) {
+    expect(book.name).to.equal("Alice Carter");
+  }
+}
+
+async function returnsNullForOrphanForeignKey() {
+  await _createDataController(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {});
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: BookListed[] };
+  const orphan = data.results.find((b) => b.title === "Lost Chapter");
+  expect(orphan).to.not.equal(undefined);
+  expect(orphan?.name).to.equal(null);
+  expect(orphan?.email).to.equal(null);
+}
+
+async function ignoresJoinedFieldOnEdit() {
+  const { bookIds, bookModel, authorIds, authorModel } =
+    await _createDataController(getFunctionName());
+
+  const editPayload = {
+    title: "Alpha Rising (revised)",
+    name: "Hacker Forged Name",
+    email: "hacker@example.com",
+  };
+  const response = await editRequest(getFunctionName(), editPayload, {
+    id: bookIds[0],
+  });
+  expect(response.status).to.equal(200);
+
+  const updatedBook = await bookModel.get(bookIds[0]);
+  expect(updatedBook?.title).to.equal("Alpha Rising (revised)");
+
+  const author = await authorModel.get(authorIds[0]);
+  expect(author?.name).to.equal("Alice Carter");
+  expect(author?.email).to.equal("alice@example.com");
+}


### PR DESCRIPTION
## Summary
- New `@Joined` field decorator (and `DataAPIMeta.setJoined`) that imports a scalar field from another table via lookup and flattens it onto the row at query time.
- Joined fields are read-only and forced to non-indexed sort; sort/filter/search now work natively in DB since the join is applied before sorting and filtering in `Query.Sort` / `DefaultRoutes.List` / `DefaultRoutes.Get`.
- `package.json` now exposes subpath exports (`./*` → `./dist/*.{d.ts,js}`) so consumers can import `@antelopejs/interface-data-api/metadata` directly (used by the new test).

## Test plan
- [ ] `pnpm test` — new `src/tests/components/joined.test.ts` covers list/get flattening, ascending/descending sort by joined field, filter by joined field, orphan FK → null, and edit body ignoring joined fields.
- [ ] `pnpm build` — verify subpath exports resolve.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `@Joined` field decorator (and `DataAPIMeta.setJoined`) that flattens a scalar field from a remote table onto each row at query time via a DB-level lookup, enabling native sort, filter, and search on joined values before pagination.

- **`src/metadata.ts`**: New `setJoined` / `Joined` decorator marks a field as read-only and non-indexed-sortable; retroactively patches `listable` and `sortable` so decorator application order doesn't matter.
- **`src/components.ts`**: New `Query.Joined` (Stream + Datum overloads) wires up the lookup pipeline; `Query.List` accepts an optional `db` parameter so the join is applied before sorting and filtering.
- **`package.json`**: Adds `./*` wildcard subpath exports so consumers can import `@antelopejs/interface-data-api/metadata` directly; requires TypeScript ≥ 4.7 with `moduleResolution: node16/nodenext/bundler`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the join logic is correct for both Stream and Datum paths, and all decorator-ordering edge cases are handled.

The core join pipeline correctly saves and restores the local FK, handles orphan rows gracefully, and integrates cleanly before sort/filter in both List and Get routes. The two findings are minor: the Datum branch leaves a temporary sentinel key in the raw DB object (harmless because `ReadProperties` filters by declared fields), and `count()` re-executes the full join pipeline. Neither causes incorrect data in any current code path.

src/components.ts — Datum branch cleanup and count double-join are worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components.ts | Adds `Query.Joined` (Stream + Datum overloads) and threads `db` through `Query.List`; Datum branch is missing the `.without(tmpKey)` cleanup that the Stream branch has, and `count()` re-runs the full join pipeline. |
| src/metadata.ts | Adds `setJoined`, `Joined` decorator, updates `setListable` and `setSortable` to handle joined fields; retroactive fixes for decorator order are correct. |
| src/index.ts | Wires `Query.Joined` into `DefaultRoutes.Get` and `DefaultRoutes.List`; ordering (join before foreign, join before sort/filter) looks correct. |
| package.json | Adds `./*` wildcard subpath export so consumers can import `@antelopejs/interface-data-api/metadata`; requires TypeScript >= 4.7 with `moduleResolution: node16/nodenext/bundler` to resolve correctly. |
| src/tests/components/joined.test.ts | New integration test covering list/get flattening, sort asc/desc, filter, orphan FK, and edit body exclusion; coverage is thorough. |
| src/antelope.test.ts | Removes stale `data-api` module source block from the test harness config; no functional impact. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant DefaultRoutes
    participant Query.List / Query.Get
    participant Query.Joined
    participant LocalTable
    participant RemoteTable
    participant Query.Foreign

    Client->>DefaultRoutes: GET /list or GET /:id
    DefaultRoutes->>Query.List / Query.Get: build base stream/datum
    Query.List / Query.Get->>LocalTable: getAll(index) or get(id)
    Query.List / Query.Get->>Query.Joined: apply joins (db, meta, stream|datum)
    loop per JoinedGroup
        Query.Joined->>Query.Joined: save localKey to tmpKey
        Query.Joined->>RemoteTable: lookup(localKey, remoteIndex)
        Query.Joined->>Query.Joined: merge remoteField onto row, restore localKey
    end
    Query.Joined-->>Query.List / Query.Get: joined stream/datum
    Query.List / Query.Get->>Query.List / Query.Get: sort + filter on merged row
    Query.List / Query.Get-->>DefaultRoutes: [sorted stream, count]
    DefaultRoutes->>Query.Foreign: resolve foreign keys (optional)
    DefaultRoutes->>Client: paginated JSON response
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/metadata.ts`, line 765-773 ([link](https://github.com/antelopejs/interface-data-api/blob/355ef87d7905e2a2310bfcacf8fd79ebf608037f/src/metadata.ts#L765-L773)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Default `@Filter()` silently queries for a native DB index on a joined field**

   When `@Filter()` is applied with no arguments, `func` is `undefined` so `useIndex` resolves to `!func = true`. `setFilter` then calls `tableMeta.indexes[field.dbName ?? name]` on the *local* table. For joined fields (like `name` on `books`) there is no native DB index, so `field.indexable` stays `undefined` — effectively falsy. This is harmless today, but if a local table ever has a same-named index as a joined field, `field.indexable` would be set to `true` and `Query.List` would use a `getAll(…, indexName)` scan on a field that does not exist natively, producing incorrect results. Joined fields should force `useIndex = false` in `setFilter`, or `setJoined` should explicitly set `field.indexable = false`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/metadata.ts
   Line: 765-773

   Comment:
   **Default `@Filter()` silently queries for a native DB index on a joined field**

   When `@Filter()` is applied with no arguments, `func` is `undefined` so `useIndex` resolves to `!func = true`. `setFilter` then calls `tableMeta.indexes[field.dbName ?? name]` on the *local* table. For joined fields (like `name` on `books`) there is no native DB index, so `field.indexable` stays `undefined` — effectively falsy. This is harmless today, but if a local table ever has a same-named index as a joined field, `field.indexable` would be set to `true` and `Query.List` would use a `getAll(…, indexName)` scan on a field that does not exist natively, producing incorrect results. Joined fields should force `useIndex = false` in `setFilter`, or `setJoined` should explicitly set `field.indexable = false`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/components.ts:394-418
The Datum branch saves a temporary key (`__joined_orig_*`) to preserve the original FK before the lookup, but unlike the Stream branch it never calls `.without(tmpKey)` to strip it out. The raw object returned from `await query` therefore contains the extra `__joined_orig_authorId` key. Today this is benign because `ReadProperties` only reads declared fields, but if the raw result is ever consumed directly (e.g. passed to `fromDatabase` and then serialised), the sentinel key would leak into the response.

```suggestion
    const datumTmpKeys: string[] = [];
    let datum: Datum<RowShape> = query as Datum<RowShape>;
    for (const group of groups) {
      const remoteFields = group.fields.map((f) => f.remoteField);
      const remoteTable = db
        .table(group.table)
        .pluck(
          "_internal",
          group.remoteIndex,
          ...remoteFields,
        ) as Table<RowShape>;
      const tmpKey = tmpKeyFor(group.localKey);
      datumTmpKeys.push(tmpKey);
      datum = datum
        .do((row) => row.merge({ [tmpKey]: row.key(group.localKey) }))
        .lookup(remoteTable, group.localKey, group.remoteIndex)
        .do((row) => {
          const merged: RowShape = {};
          const remote = row.key(group.localKey).default(emptyRemote);
          for (const f of group.fields) {
            merged[f.name] = remote.key(f.remoteField).default(null);
          }
          merged[group.localKey] = row.key(tmpKey);
          return row.merge(merged);
        }) as Datum<RowShape>;
    }
    return datum.without(...datumTmpKeys) as Datum<RowShape>;
```

### Issue 2 of 2
src/components.ts:550
**Join pipeline executed twice per list request**

`tmpRequest` already has the join applied (remote-table lookups, temporary key merges, `.without()`). Returning `[tmpRequest, tmpRequest.count()]` causes the database to execute the full join pipeline a second time just to produce the total count. For tables with many joined groups or high-cardinality FK columns this doubles the cross-table I/O on every `List` call. Consider materialising the count from a separate pre-join scan, or accepting this as a known trade-off and leaving a comment to that effect.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(joined): preserve original localKey ..."](https://github.com/antelopejs/interface-data-api/commit/f363461e0f0c2b3301e9a472845e601a1eb793fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31332230)</sub>

<!-- /greptile_comment -->