### PR TITLE
fix(components): guard null foreign values in Validation.Unlock

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -633,7 +633,11 @@ export namespace Validation {
       const key = obj[field];
       unlock(dbData, modifier, undefined, key);
       for (const [foreign, fieldData] of Object.entries(meta.fields)) {
-        if (fieldData.foreign && typeof dbData[foreign] === "object") {
+        if (
+          fieldData.foreign &&
+          dbData[foreign] &&
+          typeof dbData[foreign] === "object"
+        ) {
           unlock(dbData[foreign], modifier, undefined, key);
         }
       }

--- a/src/tests/components/modifier_key.test.ts
+++ b/src/tests/components/modifier_key.test.ts
@@ -1,0 +1,197 @@
+import path from "node:path";
+import { Controller, Parameter } from "@antelopejs/interface-api";
+import {
+  DataController,
+  DefaultRoutes,
+  RegisterDataController,
+} from "@antelopejs/interface-data-api";
+import {
+  Access,
+  AccessMode,
+  Foreign,
+  Listable,
+  ModelReference,
+  ModifierKey,
+} from "@antelopejs/interface-data-api/metadata";
+import { Schema } from "@antelopejs/interface-database";
+import {
+  BasicDataModel,
+  LocalizationModifier,
+  Localized,
+  Model,
+  RegisterSchema,
+  RegisterTable,
+  Table,
+} from "@antelopejs/interface-database-decorators";
+import { expect } from "chai";
+import {
+  getFunctionName,
+  getRequest,
+  getSchemaInstance,
+  listRequest,
+} from "../utils";
+
+const currentTestName = path
+  .basename(__filename)
+  .replace(/\.test\.(ts|js)$/, "");
+const authorTableName = `authors-${currentTestName}`;
+const postTableName = `posts-${currentTestName}`;
+const schemaName = "default";
+const locale = "en";
+
+@RegisterTable(authorTableName, schemaName)
+class Author extends Table {
+  declare _id: string;
+  declare name: string;
+  declare email: string;
+}
+class AuthorModel extends BasicDataModel(Author, authorTableName) {}
+
+@RegisterTable(postTableName, schemaName)
+class Post extends Table.with(LocalizationModifier) {
+  declare _id: string;
+  declare authorId: string | null;
+
+  @Localized()
+  declare title: string;
+}
+class PostModel extends BasicDataModel(Post, postTableName) {}
+
+interface AuthorReference {
+  _id: string;
+  name: string;
+  email: string;
+}
+
+interface PostListed {
+  _id: string;
+  authorId: AuthorReference | null;
+}
+
+const authorDataset: Partial<Author>[] = [
+  { name: "Alice Carter", email: "alice@example.com" },
+];
+
+const orphanAuthorId = "orphan-author-id";
+
+describe("Modifier key with foreign fields", () => {
+  it("gets row with resolved foreign reference", async () =>
+    await getsRowWithResolvedForeignReference());
+  it("gets row with null foreign reference", async () =>
+    await getsRowWithNullForeignReference());
+  it("gets row with dangling foreign reference", async () =>
+    await getsRowWithDanglingForeignReference());
+  it("lists rows containing null foreign references", async () =>
+    await listsRowsContainingNullForeignReferences());
+});
+
+async function _createDataController(testName: string) {
+  @RegisterDataController()
+  class _ModifierKeyTestAPI extends DataController(
+    Post,
+    {
+      list: DefaultRoutes.List,
+      get: DefaultRoutes.Get,
+    },
+    Controller(`/${testName}`),
+  ) {
+    @ModelReference()
+    @Model(PostModel)
+    declare postModel: PostModel;
+
+    @Parameter("locale", "query")
+    @ModifierKey(LocalizationModifier)
+    declare locale: string;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare _id: string;
+
+    @Listable()
+    @Access(AccessMode.ReadWrite)
+    @Foreign(Author)
+    declare authorId: Author | null;
+
+    @Listable()
+    @Access(AccessMode.ReadWrite)
+    declare title: string;
+  }
+
+  await RegisterSchema(schemaName);
+  await _dropTables();
+
+  const schemaInstance = getSchemaInstance(schemaName);
+  const authorModel = new AuthorModel(schemaInstance);
+  const postModel = new PostModel(schemaInstance);
+
+  const authorIdsRecord = await authorModel.insert(authorDataset);
+  const authorIds = Object.values(authorIdsRecord);
+
+  const postsDataset: Partial<Post>[] = [
+    { authorId: authorIds[0] },
+    { authorId: orphanAuthorId },
+    { authorId: null },
+  ];
+
+  const postIdsRecord = await postModel.insert(postsDataset);
+  const postIds = Object.values(postIdsRecord);
+
+  return { authorIds, postIds };
+}
+
+async function _dropTables() {
+  const schema = Schema.get(schemaName);
+  if (schema) {
+    await schema.instance().table(postTableName).delete();
+    await schema.instance().table(authorTableName).delete();
+  }
+}
+
+async function getsRowWithResolvedForeignReference() {
+  const { postIds } = await _createDataController(getFunctionName());
+
+  const response = await getRequest(getFunctionName(), {
+    id: postIds[0],
+    locale,
+  });
+  expect(response.status).to.equal(200);
+  const post = (await response.json()) as PostListed;
+  expect(post.authorId).to.not.equal(null);
+  expect(post.authorId?.name).to.equal("Alice Carter");
+}
+
+async function getsRowWithNullForeignReference() {
+  const { postIds } = await _createDataController(getFunctionName());
+
+  const response = await getRequest(getFunctionName(), {
+    id: postIds[2],
+    locale,
+  });
+  expect(response.status).to.equal(200);
+  const post = (await response.json()) as PostListed;
+  expect(post.authorId).to.equal(null);
+}
+
+async function getsRowWithDanglingForeignReference() {
+  const { postIds } = await _createDataController(getFunctionName());
+
+  const response = await getRequest(getFunctionName(), {
+    id: postIds[1],
+    locale,
+  });
+  expect(response.status).to.equal(200);
+  const post = (await response.json()) as PostListed;
+  expect(post.authorId).to.equal(null);
+}
+
+async function listsRowsContainingNullForeignReferences() {
+  await _createDataController(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), { locale });
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: PostListed[] };
+  expect(data.results).to.have.lengthOf(3);
+
+  const nullAuthorPosts = data.results.filter((post) => post.authorId == null);
+  expect(nullAuthorPosts).to.have.lengthOf(2);
+}


### PR DESCRIPTION
### 🔗 Linked issue

Fixes AntelopeJS/data-api#22

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a data controller declares a modifier key (e.g. `@ModifierKey(LocalizationModifier)`) and a `@Foreign` field resolves to `null` (dangling reference, or the stored value itself is `null`), `Validation.Unlock` crashed with `Cannot read properties of null (reading 'constructor')`: since `typeof null === "object"`, the null value slipped through the foreign-field check and reached `unlock(null, …)`, causing the `get`/`list` routes to 500.

This mirrors the truthiness guard already present in `Validation.ClearInternal` by checking `dbData[foreign]` before the `typeof` test.

Also adds a regression test suite (`modifier_key.test.ts`) covering a controller with a `LocalizationModifier` key and a foreign field that is resolved, `null`, or dangling. Without the fix, the `get` tests with null/dangling references fail with a 500; with it, the full suite (61 tests) passes.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a null-dereference crash in `Validation.Unlock` when a `@Foreign`-annotated field resolves to `null` (either stored as null or a dangling reference). The condition `typeof dbData[foreign] === "object"` was true for `null`, causing `unlock(null, …)` to be called and resulting in a 500 on `get`/`list` routes.

- **Fix in `src/components.ts`**: Adds a truthiness guard `dbData[foreign] &&` before the `typeof` check, mirroring the identical pattern already present in `Validation.ClearInternal` and the first loop of `Unlock` itself.
- **New test `src/tests/components/modifier_key.test.ts`**: Adds a 4-case regression suite covering a `LocalizationModifier` controller with a `@Foreign` field that is resolved, null, or dangling, plus a list route exercising multiple null entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a one-line truthiness guard that directly mirrors the identical pattern already present in two adjacent code paths, and the new test suite exercises all three foreign-field scenarios (resolved, null, dangling) on both get and list routes.

The fix is minimal and consistent with the surrounding codebase. The new regression test covers the exact crash scenario and confirms correct behaviour for all nullable-foreign-field permutations. No existing logic is altered beyond skipping the unlock call when the foreign value is falsy.

No files require special attention. The test file's reliance on Object.values insertion-order for postIds indexing is acceptable because the two null-path tests both assert the same expected value (null), so a swap between indices 1 and 2 would not affect outcomes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components.ts | One-line null guard added before `typeof` check in `Validation.Unlock`; fix is minimal, correct, and consistent with surrounding code patterns. |
| src/tests/components/modifier_key.test.ts | New regression test file; covers the bug scenarios correctly, but relies on `Object.values` insertion-order stability for `postIds` indexing and recreates shared tables on every test function call. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Route as get/list Route
    participant Unlock as Validation.Unlock
    participant DB as Database Row

    Client->>Route: "GET /:id?locale=en"
    Route->>DB: fetch dbData
    DB-->>Route: "{ authorId: null }"

    Route->>Unlock: Unlock(obj, meta, dbData)
    note over Unlock: for each modifierKey → unlock(dbData, modifier, key)
    Unlock->>Unlock: "iterate meta.fields for @Foreign"

    alt "BEFORE fix: typeof null === object → crash"
        Unlock->>Unlock: unlock(null, modifier, key)
        Unlock-->>Route: TypeError: Cannot read properties of null
        Route-->>Client: 500 Internal Server Error
    end

    alt "AFTER fix: dbData[foreign] && typeof === object"
        Unlock->>Unlock: null is falsy → skip unlock call
        Unlock-->>Route: returns normally
        Route-->>Client: "200 { authorId: null }"
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(components): guard null foreign valu..."](https://github.com/antelopejs/interface-data-api/commit/fa01afe54ad2c7389b64d20b7e59a0ee99b605cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37189271)</sub>

<!-- /greptile_comment -->