### PR TITLE
feat: add Computed field decorator for in-database computed values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Detailed documentation is available in the `docs` directory:
 - [Filters](./docs/8.filters.md) - Add filtering capabilities to list endpoints
 - [Modifiers](./docs/9.modifiers.md) - Automatic data transformation with database-decorators
 - [Joined Fields](./docs/10.joined.md) - Flatten a remote field onto rows for native sort/filter
+- [Computed Fields](./docs/11.computed.md) - In-database computed values, sortable and pageable natively
 
 ## License
 

--- a/docs/1.introduction.md
+++ b/docs/1.introduction.md
@@ -14,6 +14,7 @@ The Data API interface provides a declarative approach to building RESTful APIs 
 - **Sorting** - Mark fields as sortable to enable ordering in list queries.
 - **Foreign Key Resolution** - Automatically resolve relationships between tables with optional field plucking.
 - **Joined Fields** - Flatten a scalar field from another table onto each row so it can be sorted, filtered, and searched natively in the database.
+- **Computed Fields** - Merge in-database computed expressions (row-local values or aggregates over other tables) onto each row, natively sortable, filterable, and pageable.
 - **Filters** - Add default or custom filter logic to list endpoints using query parameters.
 - **Modifier Integration** - Automatic data transformation (encryption, hashing, localization) through database-decorators.
 
@@ -118,3 +119,4 @@ This generates the following REST endpoints:
 - [Filters](./8.filters.md) - Add filtering capabilities to list endpoints
 - [Modifiers](./9.modifiers.md) - Automatic data transformation with database-decorators
 - [Joined Fields](./10.joined.md) - Flatten a remote field onto rows for native sort/filter
+- [Computed Fields](./11.computed.md) - In-database computed values, sortable and pageable natively

--- a/docs/10.joined.md
+++ b/docs/10.joined.md
@@ -134,4 +134,4 @@ When a table class is passed, its schema is inferred from its `@RegisterTable` m
 
 ## Next Steps
 
-See the [modifiers documentation](./9.modifiers.md) to learn how automatic data transformation integrates with the Data API.
+See the [computed fields documentation](./11.computed.md) to generalize this merge mechanism to arbitrary in-database expressions, or the [modifiers documentation](./9.modifiers.md) to learn how automatic data transformation integrates with the Data API.

--- a/docs/11.computed.md
+++ b/docs/11.computed.md
@@ -1,0 +1,146 @@
+# Computed Fields
+
+## Overview
+
+The `@Computed` decorator declares a field whose value is computed in the database from an expression, then merged onto each row at query time. The expression can be a row-local computation (derived from other fields of the same row) or a per-row subquery, such as an aggregate over another table. Because the merge happens before sorting and filtering, computed fields are natively sortable, filterable, and pageable in DB — no fetch-all or in-memory sorting required.
+
+Computed fields are read-only: the value is produced by the query and is never persisted on the controller's table. Declaring a field as computed automatically sets its access mode to read-only and forces non-indexed sorting, regardless of decorator order.
+
+## Basic Usage
+
+The expression receives the row proxy and the schema instance of the controller's table. It must return a value built from the query builder (`ValueProxy` operations or a subquery), not plain JavaScript computed at request time.
+
+```typescript
+import { Computed } from "@antelopejs/interface-data-api/metadata";
+
+@RegisterTable("groups")
+class Group extends Table {
+  declare _id: string;
+  declare name: string;
+}
+
+@RegisterTable("devices")
+class Device extends Table {
+  declare _id: string;
+
+  @Index()
+  declare group_id: string;
+}
+
+@RegisterDataController()
+class GroupAPI extends DataController(
+  Group,
+  DefaultRoutes.All,
+  Controller("/groups"),
+) {
+  @ModelReference()
+  @Model(GroupModel)
+  declare groupModel: GroupModel;
+
+  @Listable()
+  @Access(AccessMode.ReadOnly)
+  declare _id: string;
+
+  @Listable()
+  @Access(AccessMode.ReadWrite)
+  declare name: string;
+
+  // Aggregate: number of devices referencing this group, computed in DB
+  @Listable()
+  @Computed(
+    (row, db) =>
+      db
+        .table("devices")
+        .getAll(row.key("_id") as unknown as string, "group_id")
+        .count(),
+    { default: 0 },
+  )
+  @Sortable()
+  declare devices_count: number;
+
+  // Row-local expression
+  @Listable()
+  @Computed((row) => (row.key("name") as ValueProxy<string>).concat("!"))
+  declare display_name: string;
+}
+```
+
+A GET request to `/groups/get?id=group-123` returns the computed values at the top level:
+
+```json
+{
+  "_id": "group-123",
+  "name": "Alpha",
+  "devices_count": 3,
+  "display_name": "Alpha!"
+}
+```
+
+## Decorator Parameters
+
+```typescript
+@Computed(expr, options?)
+```
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `expr` | `(row, db) => expression` | Yes | Expression receiving the row proxy and the schema instance; returns a `ValueProxy` expression or a subquery (`Datum`) |
+| `options.default` | `unknown` | No | Fallback merged over the computed value when the expression yields `null` |
+
+### The `default` option
+
+Aggregate subqueries yield `null` instead of their natural zero value when the underlying set is empty (a `count()` over a group with no devices returns `null`, not `0`). Calling `.default(0)` inside the subquery expression does not help: the aggregation produces no document at all, so there is nothing to apply the default to. The `options.default` value solves this by being applied at the row level, after the merge:
+
+```typescript
+@Computed((row, db) => db.table("devices").getAll(row.key("_id") as unknown as string, "group_id").count(), {
+  default: 0,
+})
+declare devices_count: number;
+```
+
+Without it, rows with an empty aggregate carry `null`, which breaks equality filters (`filter_devices_count=eq:0`) and makes sort ordering depend on BSON type ordering.
+
+## Sorting, Filtering, and Pagination
+
+Computed fields combine with `@Sortable` and `@Filter` like native columns. The framework injects the computation lazily, only when and where the value is needed:
+
+- A computed field referenced by an active filter is merged before filters run.
+- A computed field used as the sort key is merged after the total count is captured and before the non-indexed `orderBy`, so the aggregate is not paid twice.
+- A computed field requested only for display (in the pluck, neither sorted nor filtered) is merged after pagination (`slice`), so it is computed only for the returned page, not the whole collection.
+
+Sorting and pagination both stay in the database: sorting by a computed aggregate with `limit`/`offset` produces correct pages and a constant `total`.
+
+Computed fields are always sorted without a database index (`@Sortable` is forced to non-indexed), since the value does not exist as a stored column.
+
+### Filtering on numeric computed fields
+
+Filter values arrive as strings from the query string. The default filter compares them as-is, which never matches a numeric computed value (`"0"` is not `0` in BSON). Provide a custom filter function that coerces the value:
+
+```typescript
+@Computed((row, db) => db.table("devices").getAll(row.key("_id") as unknown as string, "group_id").count(), {
+  default: 0,
+})
+@Filter((_context, proxy, _key, value) =>
+  (proxy as ValueProxy<number>).eq(parseFloat(value)),
+)
+declare devices_count: number;
+```
+
+## Computed vs. Joined
+
+| Aspect | `@Computed` | `@Joined` |
+| ------ | ----------- | --------- |
+| Source | Arbitrary expression: row-local computation or per-row subquery | One scalar field from another table matched by a foreign key |
+| Typical use | Aggregates (`count`, `sum`), derived values | Flattening a referenced record's field |
+| Access | Read-only (enforced) | Read-only (enforced) |
+| Sort / filter | Native, lazily injected only where needed | Native, always applied before sort/filter |
+
+`@Joined` remains the simpler choice for the 1:1 flattening case; `@Computed` generalizes the same merge mechanism to arbitrary expressions.
+
+## Driver Support
+
+The aggregate form relies on the database driver translating a per-row subquery inside a merge into a correlated lookup (`$lookup` with `let`/`pipeline` on MongoDB). This is supported by `@antelopejs/mongodb` >= 1.2.1. Row-local expressions only use standard expression compilation and work on any driver.
+
+## Next Steps
+
+See the [joined fields documentation](./10.joined.md) for the dedicated 1:1 flattening decorator.

--- a/docs/11.computed.md
+++ b/docs/11.computed.md
@@ -51,7 +51,7 @@ class GroupAPI extends DataController(
     (row, db) =>
       db
         .table("devices")
-        .getAll(row.key("_id") as unknown as string, "group_id")
+        .getAll(row.key("_id"), "group_id")
         .count(),
     { default: 0 },
   )
@@ -92,7 +92,7 @@ A GET request to `/groups/get?id=group-123` returns the computed values at the t
 Aggregate subqueries yield `null` instead of their natural zero value when the underlying set is empty (a `count()` over a group with no devices returns `null`, not `0`). Calling `.default(0)` inside the subquery expression does not help: the aggregation produces no document at all, so there is nothing to apply the default to. The `options.default` value solves this by being applied at the row level, after the merge:
 
 ```typescript
-@Computed((row, db) => db.table("devices").getAll(row.key("_id") as unknown as string, "group_id").count(), {
+@Computed((row, db) => db.table("devices").getAll(row.key("_id"), "group_id").count(), {
   default: 0,
 })
 declare devices_count: number;
@@ -117,7 +117,7 @@ Computed fields are always sorted without a database index (`@Sortable` is force
 Filter values arrive as strings from the query string. The default filter compares them as-is, which never matches a numeric computed value (`"0"` is not `0` in BSON). Provide a custom filter function that coerces the value:
 
 ```typescript
-@Computed((row, db) => db.table("devices").getAll(row.key("_id") as unknown as string, "group_id").count(), {
+@Computed((row, db) => db.table("devices").getAll(row.key("_id"), "group_id").count(), {
   default: 0,
 })
 @Filter((_context, proxy, _key, value) =>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@antelopejs/interface-api": "^0.0.3",
     "@antelopejs/interface-api-util": "^0.0.4",
     "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-database": "^0.1.1",
+    "@antelopejs/interface-database": "^0.1.2",
     "@antelopejs/interface-database-decorators": "^0.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3
       '@antelopejs/interface-database':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.1.2
+        version: 0.1.2
       '@antelopejs/interface-database-decorators':
         specifier: ^0.1.1
         version: 0.1.1
@@ -72,8 +72,8 @@ packages:
   '@antelopejs/interface-database-decorators@0.1.1':
     resolution: {integrity: sha512-nHfwx7bPdIsDhCOO+/8AMp8j/Nuv1uqgYs9AoeJbyO1VZjHjs+vELjDKmHRxtYjlQce8CSgVdoqFavsgZyOSCQ==}
 
-  '@antelopejs/interface-database@0.1.1':
-    resolution: {integrity: sha512-b2/fgLhDVSTbr3tXIpKCfnpCGxy2Jwf2qbMPOJ1lxru+ut7ipDbdnNhWbS+doY2BRICuFuJ/IOiRiWYTOrsBsg==}
+  '@antelopejs/interface-database@0.1.2':
+    resolution: {integrity: sha512-kjFh9GV5g86xBVQt2rDbvpYnGMHgfS+p+a8Pu/g+fsFBul0Hgos1qUSxvXHqHcu1lvjLviqGIrrN3JgZUfcV1w==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1415,11 +1415,11 @@ snapshots:
     dependencies:
       '@antelopejs/interface-api': 0.0.3
       '@antelopejs/interface-core': 0.0.3
-      '@antelopejs/interface-database': 0.1.1
+      '@antelopejs/interface-database': 0.1.2
       randomstring: 1.3.1
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.1.1':
+  '@antelopejs/interface-database@0.1.2':
     dependencies:
       '@antelopejs/interface-core': 0.0.3
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -581,9 +581,7 @@ export namespace Query {
     id: string | ValueProxy<string>,
     index?: string,
   ) {
-    return index
-      ? table.getAll(id as string, index).nth(0)
-      : table.get(id as string);
+    return index ? table.getAll(id as string, index).nth(0) : table.get(id);
   }
 
   export function List<T extends Record<string, any>>(

--- a/src/components.ts
+++ b/src/components.ts
@@ -22,7 +22,7 @@ import {
   unlockrequest,
 } from "@antelopejs/interface-database-decorators/modifiers/common";
 import { GetDataControllerMeta } from ".";
-import type { DataAPIMeta, FilterValue } from "./metadata";
+import type { ComputedFieldData, DataAPIMeta, FilterValue } from "./metadata";
 
 export namespace Parameters {
   export function GetOptionOverrides<T extends Record<string, any>>(
@@ -436,6 +436,82 @@ export namespace Query {
     return datum;
   }
 
+  type ComputedEntry = [name: string, computed: ComputedFieldData];
+  type RowMapper = (
+    row: ValueProxy<Record<string, any>>,
+  ) => ValueProxy<Record<string, any>>;
+
+  function collectComputedEntries(
+    meta: DataAPIMeta,
+    only?: Set<string>,
+  ): ComputedEntry[] {
+    return Object.entries(meta.fields)
+      .filter(([name, field]) => field.computed && (!only || only.has(name)))
+      .map(([name, field]) => [name, field.computed as ComputedFieldData]);
+  }
+
+  function buildComputedMappers(
+    db: SchemaInstance<any>,
+    entries: ComputedEntry[],
+  ): RowMapper[] {
+    const mergeExpressions: RowMapper = (row) => {
+      const merged: Record<string, unknown> = {};
+      for (const [name, computed] of entries) {
+        merged[name] = computed.expr(row, db);
+      }
+      return row.merge(merged);
+    };
+    const defaulted = entries.filter(
+      ([, computed]) => computed.default !== undefined,
+    );
+    if (defaulted.length === 0) {
+      return [mergeExpressions];
+    }
+    const applyDefaults: RowMapper = (row) => {
+      const merged: Record<string, unknown> = {};
+      for (const [name, computed] of defaulted) {
+        merged[name] = row.key(name).default(computed.default);
+      }
+      return row.merge(merged);
+    };
+    return [mergeExpressions, applyDefaults];
+  }
+
+  export function Computed(
+    db: SchemaInstance<any>,
+    meta: DataAPIMeta,
+    query: Stream<any>,
+    only?: Set<string>,
+  ): Stream<any>;
+  export function Computed(
+    db: SchemaInstance<any>,
+    meta: DataAPIMeta,
+    query: Datum<any>,
+    only?: Set<string>,
+  ): Datum<any>;
+  export function Computed(
+    db: SchemaInstance<any>,
+    meta: DataAPIMeta,
+    query: Stream<any> | Datum<any>,
+    only?: Set<string>,
+  ): Stream<any> | Datum<any> {
+    const entries = collectComputedEntries(meta, only);
+    if (entries.length === 0) {
+      return query as any;
+    }
+    const mappers = buildComputedMappers(db, entries);
+    if (query instanceof Stream) {
+      return mappers.reduce(
+        (stream, mapper) => stream.map(mapper),
+        query as Stream<Record<string, any>>,
+      );
+    }
+    return mappers.reduce(
+      (datum, mapper) => datum.do(mapper),
+      query as Datum<Record<string, any>>,
+    );
+  }
+
   export async function ReadProperties(
     obj: any,
     meta: DataAPIMeta,
@@ -538,6 +614,20 @@ export namespace Query {
       tmpRequest = Joined(db, meta, tmpRequest as Stream<any>) as Stream<T>;
     }
 
+    const filteredComputed = new Set(
+      filterList
+        .map(([name]) => name)
+        .filter((name) => meta.fields[name]?.computed),
+    );
+    if (db && filteredComputed.size > 0) {
+      tmpRequest = Computed(
+        db,
+        meta,
+        tmpRequest as Stream<any>,
+        filteredComputed,
+      ) as Stream<T>;
+    }
+
     const sortField = sorting?.[0];
     const shouldSort = sortField ? meta.fields[sortField]?.sortable : undefined;
     if (shouldSort?.indexed && sortField) {
@@ -562,10 +652,24 @@ export namespace Query {
             );
       }, tmpRequest);
     }
+    const total = tmpRequest.count();
+    if (
+      db &&
+      sortField &&
+      meta.fields[sortField]?.computed &&
+      !filteredComputed.has(sortField)
+    ) {
+      tmpRequest = Computed(
+        db,
+        meta,
+        tmpRequest as Stream<any>,
+        new Set([sortField]),
+      ) as Stream<T>;
+    }
     if (shouldSort && !shouldSort.indexed && sortField) {
       tmpRequest = tmpRequest.orderBy(sortField, sorting?.[1] ?? "asc");
     }
-    return [tmpRequest, tmpRequest.count()];
+    return [tmpRequest, total];
   }
 
   export function Delete(table: Table<any>, id: string | string[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,9 @@ function displayOnlyComputedFields(
   params: Parameters.ListParameters,
   pluck: Set<string> | undefined,
 ): Set<string> {
-  const alreadyInjected = new Set(Object.keys(params.filters ?? {}));
+  const alreadyInjected = new Set(
+    Object.keys(params.filters ?? {}).filter((name) => name in meta.filters),
+  );
   if (params.sortKey) {
     alreadyInjected.add(params.sortKey);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,26 @@ export function GetDataControllerMeta(thisObj: any): DataAPIMeta {
   );
 }
 
+function displayOnlyComputedFields(
+  meta: DataAPIMeta,
+  params: Parameters.ListParameters,
+  pluck: Set<string> | undefined,
+): Set<string> {
+  const alreadyInjected = new Set(Object.keys(params.filters ?? {}));
+  if (params.sortKey) {
+    alreadyInjected.add(params.sortKey);
+  }
+  const names = Object.entries(meta.fields)
+    .filter(
+      ([name, field]) =>
+        field.computed &&
+        !alreadyInjected.has(name) &&
+        (params.noPluck || pluck?.has(name)),
+    )
+    .map(([name]) => name);
+  return new Set(names);
+}
+
 export namespace DefaultRoutes {
   class Methods {
     async get(_reqCtx: RequestContext, params: Parameters.GetParameters) {
@@ -149,6 +169,7 @@ export namespace DefaultRoutes {
       let query = Query.Get(model.table, params.id, params.index);
 
       query = Query.Joined(model.database, meta, query);
+      query = Query.Computed(model.database, meta, query);
 
       if (!params.noForeign) {
         query = Query.Foreign(model.database, meta, query);
@@ -205,6 +226,16 @@ export namespace DefaultRoutes {
       const offset = params.offset || 0;
       const limit = params.limit || 10;
       let queryPaged = query.slice(offset, limit);
+
+      const displayComputed = displayOnlyComputedFields(meta, params, pluck);
+      if (displayComputed.size > 0) {
+        queryPaged = Query.Computed(
+          model.database,
+          meta,
+          queryPaged,
+          displayComputed,
+        );
+      }
 
       if (!params.noPluck && pluck) {
         queryPaged = queryPaged.pluck("_internal", ...pluck);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -6,6 +6,8 @@ import {
   MakePropertyDecorator,
 } from "@antelopejs/interface-core/decorators";
 import type {
+  Query,
+  SchemaInstance,
   ValueProxy,
   ValueProxyOrValue,
 } from "@antelopejs/interface-database";
@@ -99,6 +101,14 @@ export interface FieldData {
   };
 
   /**
+   * In-database computed value.
+   *
+   * The expression is merged into each row at query time, enabling sort,
+   * filter, and pagination natively in DB.
+   */
+  computed?: ComputedFieldData;
+
+  /**
    * Value validator callback.
    */
   validator?: (value: unknown) => boolean | Promise<boolean>;
@@ -112,6 +122,36 @@ export interface FieldData {
    * Whether or not an `eq` filter with this field name can use an indexed lookup.
    */
   indexable?: boolean;
+}
+
+/**
+ * In-database computed field expression.
+ *
+ * Receives the row proxy and the schema instance of the controller's table.
+ * May return a row-local expression (built from `row`) or a per-row subquery
+ * (ex: an aggregate over another table).
+ */
+export type ComputedExpression = (
+  row: ValueProxy<Record<string, any>>,
+  db: SchemaInstance<any>,
+) => ValueProxyOrValue<unknown> | Query<unknown>;
+
+/**
+ * Computed field options.
+ */
+export interface ComputedOptions {
+  /**
+   * Fallback merged over the computed value when the expression yields null
+   * (ex: `0` for an aggregate count over an empty set).
+   */
+  default?: unknown;
+}
+
+/**
+ * Computed field information.
+ */
+export interface ComputedFieldData extends ComputedOptions {
+  expr: ComputedExpression;
 }
 
 type Comparison = "eq" | "ne" | "gt" | "ge" | "lt" | "le";
@@ -440,7 +480,34 @@ export class DataAPIMeta {
       field.sortable = undefined;
       return this;
     }
-    field.sortable = { indexed: !noIndex && !field.joined };
+    field.sortable = { indexed: !noIndex && !field.joined && !field.computed };
+    return this;
+  }
+
+  /**
+   * Declares a field to be computed in-database from an expression.
+   *
+   * The value is read-only (merged into the row at query time, not persisted
+   * on this table). The field becomes natively sortable/filterable/pageable
+   * since the expression is applied to the underlying query before
+   * sorting/filtering.
+   *
+   * @param name Field name
+   * @param expr Computed expression
+   * @param options Computed options
+   */
+  public setComputed(
+    name: string,
+    expr: ComputedExpression,
+    options?: ComputedOptions,
+  ) {
+    const field = this.field(name);
+    field.computed = { expr, default: options?.default };
+    field.mode = AccessMode.ReadOnly;
+    if (field.sortable?.indexed) {
+      field.sortable = { indexed: false };
+    }
+    this.recomputeAccess();
     return this;
   }
 
@@ -728,6 +795,30 @@ export const Joined = MakePropertyDecorator(
   ) => {
     GetMetadata(target.constructor, DataAPIMeta).setJoined(
       key as string,
+      options,
+    );
+  },
+);
+
+/**
+ * Declares a field whose value is computed in-database from an expression.
+ *
+ * The expression receives the row proxy and the schema instance and may
+ * return a row-local expression or a per-row subquery (ex: an aggregate over
+ * another table). The framework merges the result into each row before
+ * filters and sorting are applied, making the field natively sortable,
+ * filterable, and pageable in DB.
+ *
+ * Computed fields are auto read-only and forced to non-indexed sort.
+ *
+ * @param expr Computed expression
+ * @param options Computed options (`default`: fallback when the expression yields null)
+ */
+export const Computed = MakePropertyDecorator(
+  (target, key, expr: ComputedExpression, options?: ComputedOptions) => {
+    GetMetadata(target.constructor, DataAPIMeta).setComputed(
+      key as string,
+      expr,
       options,
     );
   },

--- a/src/tests/components/computed.test.ts
+++ b/src/tests/components/computed.test.ts
@@ -123,10 +123,7 @@ async function _createDataController(testName: string) {
     @Listable()
     @Computed(
       (row, db) =>
-        db
-          .table(deviceTableName)
-          .getAll(row.key("_id") as unknown as string, "group_id")
-          .count(),
+        db.table(deviceTableName).getAll(row.key("_id"), "group_id").count(),
       { default: 0 },
     )
     @Sortable()

--- a/src/tests/components/computed.test.ts
+++ b/src/tests/components/computed.test.ts
@@ -1,0 +1,310 @@
+import path from "node:path";
+import { Controller } from "@antelopejs/interface-api";
+import { GetMetadata } from "@antelopejs/interface-core";
+import {
+  DataController,
+  DefaultRoutes,
+  RegisterDataController,
+} from "@antelopejs/interface-data-api";
+import {
+  Access,
+  AccessMode,
+  Computed,
+  DataAPIMeta,
+  Filter,
+  Listable,
+  ModelReference,
+  Sortable,
+} from "@antelopejs/interface-data-api/metadata";
+import { Schema, type ValueProxy } from "@antelopejs/interface-database";
+import {
+  BasicDataModel,
+  Index,
+  Model,
+  RegisterSchema,
+  RegisterTable,
+  Table,
+} from "@antelopejs/interface-database-decorators";
+import { expect } from "chai";
+import {
+  editRequest,
+  getFunctionName,
+  getRequest,
+  getSchemaInstance,
+  listRequest,
+} from "../utils";
+
+const currentTestName = path
+  .basename(__filename)
+  .replace(/\.test\.(ts|js)$/, "");
+const groupTableName = `groups-${currentTestName}`;
+const deviceTableName = `devices-${currentTestName}`;
+const schemaName = "default";
+
+@RegisterTable(groupTableName, schemaName)
+class Group extends Table {
+  declare _id: string;
+  declare name: string;
+}
+class GroupModel extends BasicDataModel(Group, groupTableName) {}
+
+@RegisterTable(deviceTableName, schemaName)
+class Device extends Table {
+  declare _id: string;
+  @Index()
+  declare group_id: string;
+  declare label: string;
+}
+class DeviceModel extends BasicDataModel(Device, deviceTableName) {}
+
+interface GroupListed {
+  _id: string;
+  name: string;
+  devices_count: number;
+  display_name: string;
+}
+
+interface ListResponse {
+  results: GroupListed[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+const groupsDataset: Partial<Group>[] = [
+  { name: "Alpha" },
+  { name: "Beta" },
+  { name: "Gamma" },
+];
+
+describe("Field Computed", () => {
+  it("stores computed metadata with forced read-only and non-indexed sort", async () =>
+    await storesComputedMetadata());
+  it("lists rows with computed values", async () =>
+    await listsRowsWithComputedValues());
+  it("gets row with computed values", async () =>
+    await getsRowWithComputedValues());
+  it("sorts by computed aggregate ascending", async () =>
+    await sortsByComputedAggregateAscending());
+  it("sorts by computed aggregate descending", async () =>
+    await sortsByComputedAggregateDescending());
+  it("paginates in-DB while sorting by computed aggregate", async () =>
+    await paginatesWhileSortingByComputedAggregate());
+  it("filters by computed aggregate", async () =>
+    await filtersByComputedAggregate());
+  it("ignores computed fields on edit body", async () =>
+    await ignoresComputedFieldsOnEdit());
+});
+
+async function _createDataController(testName: string) {
+  @RegisterDataController()
+  class _ComputedTestAPI extends DataController(
+    Group,
+    {
+      list: DefaultRoutes.List,
+      get: DefaultRoutes.Get,
+      edit: DefaultRoutes.Edit,
+    },
+    Controller(`/${testName}`),
+  ) {
+    @ModelReference()
+    @Model(GroupModel)
+    declare groupModel: GroupModel;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare _id: string;
+
+    @Listable()
+    @Access(AccessMode.ReadWrite)
+    @Sortable({ noIndex: true })
+    declare name: string;
+
+    @Listable()
+    @Computed(
+      (row, db) =>
+        db
+          .table(deviceTableName)
+          .getAll(row.key("_id") as unknown as string, "group_id")
+          .count(),
+      { default: 0 },
+    )
+    @Sortable()
+    @Filter((_context, proxy, _key, value) =>
+      (proxy as ValueProxy<number>).eq(parseFloat(value)),
+    )
+    declare devices_count: number;
+
+    @Listable()
+    @Computed((row) => (row.key("name") as ValueProxy<string>).concat("!"))
+    declare display_name: string;
+  }
+
+  await RegisterSchema(schemaName);
+  await _dropTables();
+
+  const schemaInstance = getSchemaInstance(schemaName);
+  const groupModel = new GroupModel(schemaInstance);
+  const deviceModel = new DeviceModel(schemaInstance);
+
+  const groupIdsRecord = await groupModel.insert(groupsDataset);
+  const groupIds = Object.values(groupIdsRecord);
+
+  const devicesDataset: Partial<Device>[] = [
+    { group_id: groupIds[0], label: "alpha-1" },
+    { group_id: groupIds[0], label: "alpha-2" },
+    { group_id: groupIds[0], label: "alpha-3" },
+    { group_id: groupIds[1], label: "beta-1" },
+  ];
+  await deviceModel.insert(devicesDataset);
+
+  return { groupIds, groupModel, deviceModel, controller: _ComputedTestAPI };
+}
+
+async function _dropTables() {
+  const schema = Schema.get(schemaName);
+  if (schema) {
+    await schema.instance().table(deviceTableName).delete();
+    await schema.instance().table(groupTableName).delete();
+  }
+}
+
+async function _listGroups(
+  testName: string,
+  queryParams?: Record<string, string>,
+): Promise<ListResponse> {
+  const response = await listRequest(testName, queryParams);
+  if (response.status !== 200) {
+    const text = await response.text();
+    throw new Error(`list failed (${response.status}): ${text}`);
+  }
+  return (await response.json()) as ListResponse;
+}
+
+async function storesComputedMetadata() {
+  const { controller } = await _createDataController(getFunctionName());
+
+  const meta = GetMetadata(controller, DataAPIMeta, true);
+  const field = meta.fields.devices_count;
+  expect(field.computed).to.not.equal(undefined);
+  expect(field.computed?.default).to.equal(0);
+  expect(field.mode).to.equal(AccessMode.ReadOnly);
+  expect(field.sortable).to.deep.equal({ indexed: false });
+
+  meta.setSortable("devices_count", true);
+  expect(meta.fields.devices_count.sortable).to.deep.equal({ indexed: false });
+
+  expect(meta.fields.display_name.computed).to.not.equal(undefined);
+  expect(meta.fields.display_name.mode).to.equal(AccessMode.ReadOnly);
+}
+
+async function listsRowsWithComputedValues() {
+  await _createDataController(getFunctionName());
+
+  const data = await _listGroups(getFunctionName());
+  expect(data.results).to.have.lengthOf(3);
+
+  const byName = Object.fromEntries(data.results.map((g) => [g.name, g]));
+  expect(byName.Alpha.devices_count).to.equal(3);
+  expect(byName.Beta.devices_count).to.equal(1);
+  expect(byName.Gamma.devices_count).to.equal(0);
+  expect(byName.Alpha.display_name).to.equal("Alpha!");
+  expect(byName.Gamma.display_name).to.equal("Gamma!");
+}
+
+async function getsRowWithComputedValues() {
+  const { groupIds } = await _createDataController(getFunctionName());
+
+  const response = await getRequest(getFunctionName(), { id: groupIds[0] });
+  if (response.status !== 200) {
+    const text = await response.text();
+    throw new Error(`get failed (${response.status}): ${text}`);
+  }
+  const group = (await response.json()) as GroupListed;
+  expect(group.name).to.equal("Alpha");
+  expect(group.devices_count).to.equal(3);
+  expect(group.display_name).to.equal("Alpha!");
+}
+
+async function sortsByComputedAggregateAscending() {
+  await _createDataController(getFunctionName());
+
+  const data = await _listGroups(getFunctionName(), {
+    sortKey: "devices_count",
+    sortDirection: "asc",
+  });
+  expect(data.results.map((g) => g.name)).to.deep.equal([
+    "Gamma",
+    "Beta",
+    "Alpha",
+  ]);
+}
+
+async function sortsByComputedAggregateDescending() {
+  await _createDataController(getFunctionName());
+
+  const data = await _listGroups(getFunctionName(), {
+    sortKey: "devices_count",
+    sortDirection: "desc",
+  });
+  expect(data.results.map((g) => g.name)).to.deep.equal([
+    "Alpha",
+    "Beta",
+    "Gamma",
+  ]);
+}
+
+async function paginatesWhileSortingByComputedAggregate() {
+  await _createDataController(getFunctionName());
+
+  const page1 = await _listGroups(getFunctionName(), {
+    sortKey: "devices_count",
+    sortDirection: "asc",
+    limit: "2",
+    offset: "0",
+  });
+  expect(page1.results.map((g) => g.name)).to.deep.equal(["Gamma", "Beta"]);
+  expect(page1.total).to.equal(3);
+
+  const page2 = await _listGroups(getFunctionName(), {
+    sortKey: "devices_count",
+    sortDirection: "asc",
+    limit: "2",
+    offset: "2",
+  });
+  expect(page2.results.map((g) => g.name)).to.deep.equal(["Alpha"]);
+  expect(page2.total).to.equal(3);
+}
+
+async function filtersByComputedAggregate() {
+  await _createDataController(getFunctionName());
+
+  const data = await _listGroups(getFunctionName(), {
+    filter_devices_count: "eq:0",
+  });
+  expect(data.results.map((g) => g.name)).to.deep.equal(["Gamma"]);
+  expect(data.total).to.equal(1);
+}
+
+async function ignoresComputedFieldsOnEdit() {
+  const { groupIds, groupModel } = await _createDataController(
+    getFunctionName(),
+  );
+
+  const editPayload = {
+    name: "Alpha Prime",
+    devices_count: 999,
+    display_name: "Forged Name",
+  };
+  const response = await editRequest(getFunctionName(), editPayload, {
+    id: groupIds[0],
+  });
+  expect(response.status).to.equal(200);
+
+  const updatedGroup = (await groupModel.get(groupIds[0])) as unknown as
+    | Record<string, unknown>
+    | undefined;
+  expect(updatedGroup?.name).to.equal("Alpha Prime");
+  expect(updatedGroup?.devices_count).to.equal(undefined);
+  expect(updatedGroup?.display_name).to.equal(undefined);
+}


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`Query.List` sorts via `orderBy` on the DB stream, so a field whose value does not exist in-database (computed getter, aggregate count over a related table) cannot be sorted today — each project has to rewrite the whole `list` route (fetch-all → in-memory sort → manual pagination). `@Joined` already solves this for the 1:1 case by merging remote fields into the stream before sort/filter; this PR generalizes that mechanism to arbitrary expressions with a new `@Computed` decorator.

```ts
@Listable()
@Computed(
  (row, db) =>
    db.table("devices").getAll(row.key("_id") as unknown as string, "group_id").count(),
  { default: 0 },
)
@Sortable()
declare devices_count: number;
```

- **`@Computed(expr, options?)`** (`src/metadata.ts`): the expression receives the row proxy and the schema instance and returns a row-local expression or a per-row subquery, reusing the existing query builder. `setComputed` forces `AccessMode.ReadOnly` and non-indexed sort regardless of decorator order, like `@Joined`.
- **`Query.Computed`** (`src/components.ts`): merges computed fields into the row, mirroring the `Query.Joined` Stream/Datum double branch. The optional `default` is applied in a follow-up map at the parent level because an aggregate over an empty set yields `null` in-database (the aggregation produces no document, so a `.default(0)` inside the subquery is inoperative).
- **Lazy injection in `Query.List`**: computed fields referenced by an active filter are merged before filters; the total `count()` is captured before the sort-only injection so the aggregate is not paid twice; the sort key is merged just before the non-indexed `orderBy`.
- **`DefaultRoutes.list`**: display-only computed fields (in the pluck, neither sorted nor filtered) are merged after `slice`, so they are computed only for the returned page. **`DefaultRoutes.get`** applies `Query.Computed` right after `Query.Joined`.
- **Write path**: nothing to do — forced ReadOnly already excludes the field from `WriteProperties` (covered by a test).

Validated on `@antelopejs/mongodb` 1.2.1 (mongodb-memory-server): the driver translates the per-row subquery into a correlated `$lookup`, and sort/filter/pagination/count all stay in DB after the merge.

Follow-ups (separate PRs/issues):
- `@antelopejs/mongodb`: the subquery handler hardcodes `$ifNull → null` instead of using `reductionDefault`, hence the `default` option workaround.
- `@antelopejs/interface-database`: widen `get`/`getAll` key typing to `ValueProxyOrValue` to remove the `as unknown as string` casts (runtime already supports proxies).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `@Computed` decorator, which merges an arbitrary in-database expression (row-local or a per-row aggregate subquery) onto each row at query time, enabling native sort, filter, and pagination without a full-collection fetch. The implementation mirrors `@Joined`'s lazy-injection strategy and is validated by a comprehensive test suite against a real MongoDB memory-server.

- **`@Computed` + `Query.Computed`** (`src/metadata.ts`, `src/components.ts`): new decorator and query helper with `Stream`/`Datum` overloads; `setComputed` forces `AccessMode.ReadOnly` and non-indexed sort regardless of decorator order.
- **Lazy injection in `Query.List`** (`src/components.ts`): computed fields referenced by active filters are merged before filters; the `count()` total is captured before the sort-only injection so the per-row aggregate is not paid twice; display-only fields are merged after `slice` in `DefaultRoutes.list`.
- **`DefaultRoutes.get`** (`src/index.ts`): unconditionally applies `Query.Computed` after `Query.Joined`, providing all computed values on single-document fetches.

<h3>Confidence Score: 5/5</h3>

Safe to merge — core injection logic, decorator-order handling, and write-path exclusion are all correct and covered by tests.

The lazy injection strategy is well-structured: computed fields are injected at the right pipeline stage for each use-case (filter, sort, display), the total count is captured before the per-row aggregate cost is incurred for sorting, and the write-path exclusion via forced ReadOnly is enforced and tested. No correctness issues were found in the changed code paths.

src/components.ts — the sort injection condition could include a shouldSort guard for defensive correctness when Query.List is called outside DefaultRoutes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/metadata.ts | Adds ComputedExpression type, ComputedOptions/ComputedFieldData interfaces, FieldData.computed field, DataAPIMeta.setComputed(), and the @Computed decorator; decorator-order safety is correct — setSortable and setComputed both guard against indexed sort. |
| src/components.ts | Adds Query.Computed (Stream/Datum overloads), collectComputedEntries, buildComputedMappers, and wires lazy injection into Query.List for filtered/sorted/display-only computed fields; sort injection lacks a shouldSort guard, allowing a non-sortable computed field to be injected unnecessarily when Query.List is called directly. |
| src/index.ts | Adds displayOnlyComputedFields helper (correctly filtered by meta.filters) and wires Query.Computed into DefaultRoutes.get (unconditional) and DefaultRoutes.list (display-only, post-slice). |
| src/tests/components/computed.test.ts | New test suite covering metadata enforcement, list/get with computed values, ascending/descending sort, in-DB pagination while sorting by aggregate, filter on aggregate, and write-path exclusion. |
| docs/11.computed.md | New documentation page for @Computed — covers basic usage, decorator parameters, the null-aggregate default workaround, lazy injection strategy, numeric filter coercion caveat, and comparison with @Joined. |
| package.json | Bumps @antelopejs/interface-database peer dependency from ^0.1.1 to ^0.1.2 to pick up new Query/SchemaInstance exports needed by ComputedExpression. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Query.List called] --> B[Query.Joined]
    B --> C{Any active filters\non computed fields?}
    C -- Yes --> D[Query.Computed\nfilteredComputed only]
    D --> E[Apply filters]
    C -- No --> E
    E --> F[total = stream.count]
    F --> G{sortField is computed\nand not yet injected?}
    G -- Yes --> H[Query.Computed\nsortField only]
    H --> I[orderBy sortField]
    G -- No --> I
    I --> J[return stream + total]
    J --> K[DefaultRoutes.list:\nquery.slice offset+limit]
    K --> L{Display-only\ncomputed fields?}
    L -- Yes --> M[Query.Computed\ndisplay-only, post-slice]
    M --> N[pluck listable fields]
    L -- No --> N
    N --> O[Return page results]
```

<sub>Reviews (3): Last reviewed commit: ["chore(deps): bump @antelopejs/interface-..."](https://github.com/antelopejs/interface-data-api/commit/6e8216f665ff03b8c1820686a6e0765f87bebc2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37264173)</sub>

<!-- /greptile_comment -->