### PR TITLE
chore(deps): interface deps as bounded peer + pinned dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,12 @@
     "release": "pnpm run lint && pnpm run prepack && release-it",
     "test": "pnpm run build && ajs module test ."
   },
-  "dependencies": {
-    "@antelopejs/interface-api": "^0.0.3",
-    "@antelopejs/interface-api-util": "^0.0.4",
-    "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-database": "^0.1.2",
-    "@antelopejs/interface-database-decorators": "^0.1.1"
-  },
   "devDependencies": {
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-api-util": "^0.1.1",
+    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-database": "^0.1.3",
+    "@antelopejs/interface-database-decorators": "^0.1.3",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -58,6 +56,13 @@
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-api-util": ">=0.0.4 <1.0.0",
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-database": ">=0.1.2 <1.0.0",
+    "@antelopejs/interface-database-decorators": ">=0.1.1 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,22 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@antelopejs/interface-api':
-        specifier: ^0.0.3
-        version: 0.0.3
-      '@antelopejs/interface-api-util':
-        specifier: ^0.0.4
-        version: 0.0.4
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
-      '@antelopejs/interface-database':
-        specifier: ^0.1.2
-        version: 0.1.2
-      '@antelopejs/interface-database-decorators':
-        specifier: ^0.1.1
-        version: 0.1.1
     devDependencies:
+      '@antelopejs/interface-api':
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-api-util':
+        specifier: ^0.1.1
+        version: 0.1.1(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-core':
+        specifier: ^0.0.5
+        version: 0.0.5
+      '@antelopejs/interface-database':
+        specifier: ^0.1.3
+        version: 0.1.3(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-database-decorators':
+        specifier: ^0.1.3
+        version: 0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.5))
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2
@@ -60,20 +59,31 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api-util@0.0.4':
-    resolution: {integrity: sha512-endTnsX2E6Y9DE7nSBUou/+Kt9xu38ibDKv1y7fph7XJBKWxLJRd01TzHRHnkvg7KdZLsjJHEmN+QirZD0YxZg==}
+  '@antelopejs/interface-api-util@0.1.1':
+    resolution: {integrity: sha512-8q1diSFuq5CULr9T/Dzo3DAOKmoN3zu84w3PgV2aGRPT3nMujcOxHyR+DEv9iA1ZxirUx5oskBmWVCaXtHNLVQ==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-api@0.0.3':
-    resolution: {integrity: sha512-64UrrttRAjA1LsXwDskh/UVcXDFpH2+gxJHCT+F8YGLPDJE1XzVUW6/YeG441J+zsFJTnaU6Vlt90TwWumcpCA==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
-  '@antelopejs/interface-database-decorators@0.1.1':
-    resolution: {integrity: sha512-nHfwx7bPdIsDhCOO+/8AMp8j/Nuv1uqgYs9AoeJbyO1VZjHjs+vELjDKmHRxtYjlQce8CSgVdoqFavsgZyOSCQ==}
+  '@antelopejs/interface-database-decorators@0.1.3':
+    resolution: {integrity: sha512-yPSP7cYh/7nhj1y2bOWvJ1idErWqI4EsYppVg3XOy7KEaZ+RvKodwFYDle0dqsFp9UNtR8p3m0bg0YasZrAayA==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-database': '>=0.1.1 <1.0.0'
 
-  '@antelopejs/interface-database@0.1.2':
-    resolution: {integrity: sha512-kjFh9GV5g86xBVQt2rDbvpYnGMHgfS+p+a8Pu/g+fsFBul0Hgos1qUSxvXHqHcu1lvjLviqGIrrN3JgZUfcV1w==}
+  '@antelopejs/interface-database@0.1.3':
+    resolution: {integrity: sha512-tMMrQz0IFz1m82O6vYMU9Jbr2x4ZV/nTwBoViONrDuSZrJona3M1lglFh2F6ltS4LaJTsoUXr+qZGupPz2TGaA==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1398,30 +1408,30 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api-util@0.0.4':
+  '@antelopejs/interface-api-util@0.1.1(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.3
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-api@0.0.3':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-core@0.0.3':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database-decorators@0.1.1':
+  '@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.5))':
     dependencies:
-      '@antelopejs/interface-api': 0.0.3
-      '@antelopejs/interface-core': 0.0.3
-      '@antelopejs/interface-database': 0.1.2
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-core': 0.0.5
+      '@antelopejs/interface-database': 0.1.3(@antelopejs/interface-core@0.0.5)
       randomstring: 1.3.1
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.1.2':
+  '@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.5
 
   '@biomejs/biome@2.3.2':
     optionalDependencies:


### PR DESCRIPTION
## What
Move `@antelopejs/interface-*` from `dependencies` to `peerDependencies` (bounded `>=<original floor> <1.0.0`), mirrored in `devDependencies` pinned to the latest published versions.

## Why
Interfaces are host-provided runtime singletons. Peer ranges avoid dual installs and pinning overrides in consumers. devDependencies are pinned to latest (not the peer range) because pnpm resolves direct dependency ranges to their lowest satisfying version (lowest-direct), which would otherwise build against the floor.

## Verification
- interface-core resolves to a single 0.0.5 (no dual version)
- `pnpm build` ✅
- `pnpm lint` ✅

Depends on the couche 0/1 interface releases being published (now done).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restructures how `@antelopejs/interface-*` packages are declared: they move from `dependencies` to `peerDependencies` (with `>=<original-floor> <1.0.0` bounds) and are mirrored in `devDependencies` at bumped versions so pnpm's `lowest-direct` strategy builds against up-to-date code rather than the floor.

- **`peerDependencies`** added for all five interface packages with the original lower bounds preserved and a `<1.0.0` upper cap, ensuring the host provides a single runtime singleton.
- **`devDependencies`** are updated to newer minor/patch releases (`interface-api-util` jumps from `0.0.4` → `0.1.1`, `interface-database*` to `0.1.3`) and the lockfile is regenerated with correct peer-resolved snapshots.
- The peer lower bound for `@antelopejs/interface-api-util` stays at `>=0.0.4` even though the package is now built and tested against `0.1.1`, a different minor series in pre-1.0 semver that may contain breaking changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the peer floor for `interface-api-util` is intentional and backward compatibility with `0.0.x` has been verified; otherwise the floor should be raised to `>=0.1.1`.

The restructuring itself is clean and the lockfile is consistent, but the `interface-api-util` peer lower bound was preserved at `>=0.0.4` while the actual build target jumped to `0.1.1` — a minor-series change in pre-1.0 semver that can carry breaking API differences. A consumer already pinned to `0.0.x` would silently satisfy the peer range while potentially hitting missing symbols at runtime.

`package.json` — specifically the `peerDependencies` lower bound for `@antelopejs/interface-api-util`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves interface deps from `dependencies` to `peerDependencies` with bounded ranges and mirrors them in `devDependencies` at newer versions; peer floor for `interface-api-util` (>=0.0.4) lags behind the tested devDep version (^0.1.1) across a minor boundary in 0.x semver. |
| pnpm-lock.yaml | Lockfile correctly updated to reflect devDependency entries for all interface packages at their new resolved versions; snapshots include proper peer-resolved identifiers. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph before["Before (dependencies)"]
        A["@antelopejs/interface-data-api"] -->|"dependencies ^0.0.3"| B["interface-api"]
        A -->|"dependencies ^0.0.4"| C["interface-api-util"]
        A -->|"dependencies ^0.0.3"| D["interface-core"]
        A -->|"dependencies ^0.1.2"| E["interface-database"]
        A -->|"dependencies ^0.1.1"| F["interface-database-decorators"]
    end

    subgraph after["After (peerDependencies + devDependencies)"]
        G["@antelopejs/interface-data-api"] -.->|"peer >=0.0.3 <1.0.0"| H["interface-api"]
        G -.->|"peer >=0.0.4 <1.0.0 ⚠️"| I["interface-api-util"]
        G -.->|"peer >=0.0.3 <1.0.0"| J["interface-core"]
        G -.->|"peer >=0.1.2 <1.0.0"| K["interface-database"]
        G -.->|"peer >=0.1.1 <1.0.0"| L["interface-database-decorators"]
        G -->|"dev ^0.0.5"| H
        G -->|"dev ^0.1.1"| I
        G -->|"dev ^0.0.5"| J
        G -->|"dev ^0.1.3"| K
        G -->|"dev ^0.1.3"| L
    end

    style I fill:#ffcccc
    style after fill:#f0f8f0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph before["Before (dependencies)"]
        A["@antelopejs/interface-data-api"] -->|"dependencies ^0.0.3"| B["interface-api"]
        A -->|"dependencies ^0.0.4"| C["interface-api-util"]
        A -->|"dependencies ^0.0.3"| D["interface-core"]
        A -->|"dependencies ^0.1.2"| E["interface-database"]
        A -->|"dependencies ^0.1.1"| F["interface-database-decorators"]
    end

    subgraph after["After (peerDependencies + devDependencies)"]
        G["@antelopejs/interface-data-api"] -.->|"peer >=0.0.3 <1.0.0"| H["interface-api"]
        G -.->|"peer >=0.0.4 <1.0.0 ⚠️"| I["interface-api-util"]
        G -.->|"peer >=0.0.3 <1.0.0"| J["interface-core"]
        G -.->|"peer >=0.1.2 <1.0.0"| K["interface-database"]
        G -.->|"peer >=0.1.1 <1.0.0"| L["interface-database-decorators"]
        G -->|"dev ^0.0.5"| H
        G -->|"dev ^0.1.1"| I
        G -->|"dev ^0.0.5"| J
        G -->|"dev ^0.1.3"| K
        G -->|"dev ^0.1.3"| L
    end

    style I fill:#ffcccc
    style after fill:#f0f8f0
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.json:62
**Peer floor for `interface-api-util` predates a minor-version break**

The peer range keeps the original `>=0.0.4` floor, but the devDependency (and lockfile) bumped all the way to `0.1.1`. In pre-1.0.0 semver, a `0.0.x → 0.1.x` jump signals a potentially breaking change; that's precisely why pnpm's `lowest-direct` would have been resolving to `0.0.4` before. A downstream consumer that already has `@antelopejs/interface-api-util@0.0.x` installed will satisfy the peer constraint without a warning, but this package's compiled code was only ever tested against `0.1.x` APIs — leading to silent runtime failures if any `0.1.x`-only symbols are used. The floor should be raised to `>=0.1.1` (matching the tested dev baseline) unless you have confirmed that every API used here existed in `0.0.4`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-data-api/commit/05dd6bd5f4bf73c94bb2478e510d8b0ab0da5491) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37879561)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->