### PR TITLE
fix: resolve target @Joined fields through relation lookups

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -22,7 +22,12 @@ import {
   unlockrequest,
 } from "@antelopejs/interface-database-decorators/modifiers/common";
 import { GetDataControllerMeta } from ".";
-import type { ComputedFieldData, DataAPIMeta, FilterValue } from "./metadata";
+import type {
+  ComputedFieldData,
+  DataAPIMeta,
+  FilterValue,
+  ForeignJoinedRef,
+} from "./metadata";
 
 export namespace Parameters {
   export function GetOptionOverrides<T extends Record<string, any>>(
@@ -258,8 +263,15 @@ export namespace Query {
         if (!field.foreign || (pluck && !pluck.has(name))) {
           continue;
         }
-        const [table, _tableClass, index, _multi, pluckField, schemaName] =
-          field.foreign;
+        const [
+          table,
+          _tableClass,
+          index,
+          multi,
+          pluckField,
+          schemaName,
+          targetJoined,
+        ] = field.foreign;
         const other = resolveSchemaDb(db, schemaName).table(table);
         if (pluckField) {
           query = query.lookup(
@@ -270,6 +282,9 @@ export namespace Query {
         } else {
           query = query.lookup(other, name, index || "_id");
         }
+        if (!multi && targetJoined && targetJoined.length > 0) {
+          query = applyForeignJoinedStream(db, query, name, targetJoined);
+        }
       }
       return query;
     } else {
@@ -279,8 +294,15 @@ export namespace Query {
           if (!field.foreign || (pluck && !pluck.has(name))) {
             continue;
           }
-          const [table, _tableClass, index, multi, pluckField, schemaName] =
-            field.foreign;
+          const [
+            table,
+            _tableClass,
+            index,
+            multi,
+            pluckField,
+            schemaName,
+            targetJoined,
+          ] = field.foreign;
           const remoteDb = resolveSchemaDb(db, schemaName);
           if (multi) {
             changedFields[name] = (obj.key(name) as ValueProxy<string[]>)
@@ -300,17 +322,102 @@ export namespace Query {
                 return foreignObject.default(null);
               });
           } else {
-            changedFields[name] = Get(
+            let foreignObject: Datum<any> = Get(
               remoteDb.table(table),
               obj.key(name) as ValueProxy<string>,
               index,
-            ).default(null);
+            );
+            if (targetJoined && targetJoined.length > 0) {
+              foreignObject = applyForeignJoinedDatum(
+                db,
+                foreignObject,
+                targetJoined,
+              );
+            }
+            changedFields[name] = foreignObject.default(null);
           }
         }
         return obj.merge(changedFields);
       };
       return query.do(oldForeign);
     }
+  }
+
+  /**
+   * Re-materializes the `@Joined` fields of a relation target on the looked-up
+   * sub-object (Stream/list path). The base `Foreign` lookup only plucks the
+   * target's physical columns, so a joined label would come back empty; here we
+   * resolve each joined field with a second lookup keyed on the target's
+   * (already plucked) local key, then merge it back into the relation object.
+   */
+  function applyForeignJoinedStream(
+    db: SchemaInstance<any>,
+    stream: Stream<any>,
+    foreignName: string,
+    groups: ForeignJoinedRef[],
+  ): Stream<any> {
+    let s = stream;
+    for (const group of groups) {
+      const remoteDb = resolveSchemaDb(db, group.schemaName);
+      const remoteTable = remoteDb
+        .table(group.table)
+        .pluck("_internal", group.remoteIndex, group.remoteField) as Table<any>;
+      const tmpKey = `__fjoin_${foreignName}_${group.name}`;
+      s = s
+        .map((row) =>
+          row.merge({
+            [tmpKey]: row.key(foreignName).default({}).key(group.localKey),
+          }),
+        )
+        .lookup(remoteTable, tmpKey, group.remoteIndex)
+        .map((row) =>
+          row.merge({
+            [foreignName]: row
+              .key(foreignName)
+              .default({})
+              .merge({
+                [group.name]: row
+                  .key(tmpKey)
+                  .default({})
+                  .key(group.remoteField)
+                  .default(null),
+              }),
+          }),
+        )
+        .without(tmpKey) as Stream<any>;
+    }
+    return s;
+  }
+
+  /**
+   * Datum/get counterpart of {@link applyForeignJoinedStream}: resolves each of
+   * the target's `@Joined` fields with a secondary `Get` and merges it into the
+   * relation object.
+   */
+  function applyForeignJoinedDatum(
+    db: SchemaInstance<any>,
+    datum: Datum<any>,
+    groups: ForeignJoinedRef[],
+  ): Datum<any> {
+    let d = datum;
+    for (const group of groups) {
+      const remoteDb = resolveSchemaDb(db, group.schemaName);
+      // Use the raw table here (not a plucked stream): `Get` relies on
+      // `getAll`/`get`, which exist on Selection/Table but not on a Stream.
+      const remoteTable = remoteDb.table(group.table);
+      d = d.do((row) =>
+        row.merge({
+          [group.name]: Get(
+            remoteTable,
+            row.key(group.localKey) as ValueProxy<string>,
+            group.remoteIndex,
+          )
+            .key(group.remoteField)
+            .default(null),
+        }),
+      ) as Datum<any>;
+    }
+    return d;
   }
 
   interface JoinedGroup {

--- a/src/components.ts
+++ b/src/components.ts
@@ -273,16 +273,29 @@ export namespace Query {
           targetJoined,
         ] = field.foreign;
         const other = resolveSchemaDb(db, schemaName).table(table);
+        const hasTargetJoined = !multi && !!targetJoined?.length;
         if (pluckField) {
+          // The join keys of the target's @Joined fields must be fetched too
+          // (so the second lookup can resolve them), but they are NOT stored in
+          // `foreign[4]`, so they get stripped from the response by
+          // `ClearInternal` afterwards.
+          const lookupPluck = hasTargetJoined
+            ? Array.from(
+                new Set([
+                  ...pluckField,
+                  ...targetJoined.map((g) => g.localKey),
+                ]),
+              )
+            : pluckField;
           query = query.lookup(
-            other.pluck("_internal", ...pluckField) as Table<any>,
+            other.pluck("_internal", ...lookupPluck) as Table<any>,
             name,
             index || "_id",
           );
         } else {
           query = query.lookup(other, name, index || "_id");
         }
-        if (!multi && targetJoined && targetJoined.length > 0) {
+        if (hasTargetJoined) {
           query = applyForeignJoinedStream(db, query, name, targetJoined);
         }
       }
@@ -366,22 +379,22 @@ export namespace Query {
       s = s
         .map((row) =>
           row.merge({
-            [tmpKey]: row.key(foreignName).default({}).key(group.localKey),
+            [tmpKey]: row.key(foreignName).key(group.localKey),
           }),
         )
         .lookup(remoteTable, tmpKey, group.remoteIndex)
         .map((row) =>
           row.merge({
-            [foreignName]: row
-              .key(foreignName)
-              .default({})
-              .merge({
-                [group.name]: row
-                  .key(tmpKey)
-                  .default({})
-                  .key(group.remoteField)
-                  .default(null),
-              }),
+            // For an orphan foreign key this yields `{ [joined]: null }`; it is
+            // normalized back to a null relation in `ClearInternal` (the DSL has
+            // no value-level conditional to do it here).
+            [foreignName]: row.key(foreignName).merge({
+              [group.name]: row
+                .key(tmpKey)
+                .default({})
+                .key(group.remoteField)
+                .default(null),
+            }),
           }),
         )
         .without(tmpKey) as Stream<any>;
@@ -897,6 +910,25 @@ export namespace Validation {
             const plain = toPlainData(data);
             if (!foreign?.[4]) {
               return plain;
+            }
+            // An orphan foreign key whose target exposes @Joined fields produces
+            // an object with only those joined fields (all null) and none of the
+            // physical pluck fields. Normalize it back to a null relation, so it
+            // matches the get path and non-joined foreigns (which already null).
+            const targetJoined = foreign[6];
+            if (targetJoined?.length) {
+              const joinedNames = new Set(targetJoined.map((g) => g.name));
+              const physicalKeys = foreign[4].filter(
+                (k) => !joinedNames.has(k),
+              );
+              if (
+                physicalKeys.length > 0 &&
+                physicalKeys.every(
+                  (k) => plain[k] === null || plain[k] === undefined,
+                )
+              ) {
+                return null;
+              }
             }
             const plainPlucked: Record<string, unknown> = {};
             for (const key of foreign[4]) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -30,6 +30,20 @@ export enum AccessMode {
 }
 
 /**
+ * A `@Joined` field declared on the target of a relation, captured so the
+ * foreign lookup can re-materialize it (joined fields are not physical columns,
+ * so a plain pluck of the target table would return them empty).
+ */
+export interface ForeignJoinedRef {
+  name: string;
+  table: string;
+  localKey: string;
+  remoteField: string;
+  remoteIndex: string;
+  schemaName?: string;
+}
+
+/**
  * DataAPI Metadata field information.
  */
 export interface FieldData {
@@ -79,6 +93,7 @@ export interface FieldData {
     multi?: true,
     pluck?: string[],
     schemaName?: string,
+    targetJoined?: ForeignJoinedRef[],
   ];
 
   /**
@@ -583,6 +598,7 @@ export class DataAPIMeta {
     multi?: boolean,
     pluck?: string[],
     schema?: string,
+    targetMeta?: DataAPIMeta,
   ) {
     const resolved = resolveTableReference(
       this.schemaName,
@@ -590,13 +606,50 @@ export class DataAPIMeta {
       schema,
       `foreign field "${name}"`,
     );
+
+    // Capture the target's `@Joined` fields so the foreign lookup can
+    // re-materialize them. A joined field is not a physical column, so a plain
+    // pluck of the target table returns it empty; we resolve it with a second
+    // lookup at query time (see `Query.Foreign`). Only joined fields that are
+    // actually requested (present in `pluck`) are captured, and their
+    // `localKey` is added to the pluck so the join key is fetched.
+    let finalPluck = pluck;
+    let targetJoined: ForeignJoinedRef[] | undefined;
+    if (targetMeta) {
+      const pluckSet = pluck ? new Set(pluck) : undefined;
+      const groups: ForeignJoinedRef[] = [];
+      const extraKeys = new Set<string>();
+      for (const [fieldName, field] of Object.entries(targetMeta.fields)) {
+        if (!field.joined || (pluckSet && !pluckSet.has(fieldName))) {
+          continue;
+        }
+        const j = field.joined;
+        groups.push({
+          name: fieldName,
+          table: j.table,
+          localKey: j.localKey,
+          remoteField: j.remoteField,
+          remoteIndex: j.remoteIndex,
+          schemaName: j.schemaName,
+        });
+        extraKeys.add(j.localKey);
+      }
+      if (groups.length > 0) {
+        targetJoined = groups;
+        if (pluck) {
+          finalPluck = Array.from(new Set([...pluck, ...extraKeys]));
+        }
+      }
+    }
+
     this.field(name).foreign = [
       resolved.tableName,
       resolved.tableClass,
       index,
       multi || undefined,
-      pluck || undefined,
+      finalPluck || undefined,
       resolved.schemaName,
+      targetJoined,
     ];
     return this;
   }
@@ -841,10 +894,19 @@ export const Foreign = MakeMethodAndPropertyDecorator(
     multi?: boolean,
     pluck?: string[],
     schema?: string,
+    targetMeta?: DataAPIMeta,
   ) => {
     GetMetadata(target.constructor, DataAPIMeta)
       .setDescriptor(key as string, desc)
-      .setForeign(key as string, table, index, multi, pluck, schema);
+      .setForeign(
+        key as string,
+        table,
+        index,
+        multi,
+        pluck,
+        schema,
+        targetMeta,
+      );
   },
 );
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -611,14 +611,15 @@ export class DataAPIMeta {
     // re-materialize them. A joined field is not a physical column, so a plain
     // pluck of the target table returns it empty; we resolve it with a second
     // lookup at query time (see `Query.Foreign`). Only joined fields that are
-    // actually requested (present in `pluck`) are captured, and their
-    // `localKey` is added to the pluck so the join key is fetched.
-    let finalPluck = pluck;
+    // actually requested (present in `pluck`) are captured. Their `localKey`
+    // is deliberately NOT added to the stored pluck: `foreign[4]` also drives
+    // response field filtering (`Validation.ClearInternal`), so adding the join
+    // key here would leak it into the API output. `Query.Foreign` extends the
+    // lookup pluck with the join keys at query time instead.
     let targetJoined: ForeignJoinedRef[] | undefined;
     if (targetMeta) {
       const pluckSet = pluck ? new Set(pluck) : undefined;
       const groups: ForeignJoinedRef[] = [];
-      const extraKeys = new Set<string>();
       for (const [fieldName, field] of Object.entries(targetMeta.fields)) {
         if (!field.joined || (pluckSet && !pluckSet.has(fieldName))) {
           continue;
@@ -632,13 +633,9 @@ export class DataAPIMeta {
           remoteIndex: j.remoteIndex,
           schemaName: j.schemaName,
         });
-        extraKeys.add(j.localKey);
       }
       if (groups.length > 0) {
         targetJoined = groups;
-        if (pluck) {
-          finalPluck = Array.from(new Set([...pluck, ...extraKeys]));
-        }
       }
     }
 
@@ -647,7 +644,7 @@ export class DataAPIMeta {
       resolved.tableClass,
       index,
       multi || undefined,
-      finalPluck || undefined,
+      pluck || undefined,
       resolved.schemaName,
       targetJoined,
     ];

--- a/src/tests/components/foreign_joined.test.ts
+++ b/src/tests/components/foreign_joined.test.ts
@@ -85,6 +85,8 @@ describe("Foreign relation with @Joined target label", () => {
     await returnsNullForOrphanRelation());
   it("resolves a joined label through a relation in get", async () =>
     await resolvesJoinedLabelInGet());
+  it("returns null relation for an orphan foreign key in get", async () =>
+    await returnsNullForOrphanRelationInGet());
 });
 
 async function _setup(testName: string) {
@@ -198,6 +200,12 @@ async function resolvesJoinedLabelInList() {
   expect(alpha, "row for Alpha Rising").to.not.equal(undefined);
   // Core regression: the joined label resolves through the relation.
   expect(alpha?.book?.authorName).to.equal("Alice Carter");
+  // The join key must not leak: only the requested fields are exposed.
+  expect(Object.keys(alpha?.book ?? {}).sort()).to.deep.equal([
+    "_id",
+    "authorName",
+    "title",
+  ]);
 
   const beta = data.results.find((s) => s.book?.title === "Beta Stories");
   expect(beta?.book?.authorName).to.equal("Bob Stone");
@@ -210,14 +218,12 @@ async function returnsNullForOrphanRelation() {
   expect(response.status).to.equal(200);
   const data = (await response.json()) as { results: ShelfListed[] };
 
+  const resolved = data.results.filter((s) => s.book?.title);
+  expect(resolved).to.have.lengthOf(2);
   // The orphan shelf points to a non-existent book → relation stays null.
-  const titles = data.results.map((s) => s.book?.title);
-  expect(titles).to.include("Alpha Rising");
-  const orphan = data.results.find(
-    (s) => s.book === null || s.book?.title === undefined,
-  );
+  const orphan = data.results.find((s) => !s.book?.title);
   expect(orphan, "orphan relation row present").to.not.equal(undefined);
-  expect(orphan?.book?.authorName ?? null).to.equal(null);
+  expect(orphan?.book, "orphan relation value").to.equal(null);
 }
 
 async function resolvesJoinedLabelInGet() {
@@ -231,4 +237,17 @@ async function resolvesJoinedLabelInGet() {
   const shelf = (await response.json()) as ShelfListed;
   expect(shelf.book?.title).to.equal("Alpha Rising");
   expect(shelf.book?.authorName).to.equal("Alice Carter");
+}
+
+async function returnsNullForOrphanRelationInGet() {
+  const { shelfIds } = await _setup(getFunctionName());
+
+  // shelfIds[2] points to an orphan book id.
+  const response = await getRequest(getFunctionName(), { id: shelfIds[2] });
+  if (response.status !== 200) {
+    const text = await response.text();
+    throw new Error(`get orphan failed (${response.status}): ${text}`);
+  }
+  const shelf = (await response.json()) as ShelfListed;
+  expect(shelf.book, "orphan relation value in get").to.equal(null);
 }

--- a/src/tests/components/foreign_joined.test.ts
+++ b/src/tests/components/foreign_joined.test.ts
@@ -1,0 +1,234 @@
+import path from "node:path";
+import { Controller } from "@antelopejs/interface-api";
+import { GetMetadata } from "@antelopejs/interface-core";
+import {
+  DataController,
+  DefaultRoutes,
+  RegisterDataController,
+} from "@antelopejs/interface-data-api";
+import {
+  Access,
+  AccessMode,
+  DataAPIMeta,
+  Foreign,
+  Joined,
+  Listable,
+  ModelReference,
+} from "@antelopejs/interface-data-api/metadata";
+import { Schema } from "@antelopejs/interface-database";
+import {
+  BasicDataModel,
+  Model,
+  RegisterSchema,
+  RegisterTable,
+  Table,
+} from "@antelopejs/interface-database-decorators";
+import { expect } from "chai";
+import {
+  getFunctionName,
+  getRequest,
+  getSchemaInstance,
+  listRequest,
+} from "../utils";
+
+const currentTestName = path
+  .basename(__filename)
+  .replace(/\.test\.(ts|js)$/, "");
+const authorTableName = `authors-${currentTestName}`;
+const bookTableName = `books-${currentTestName}`;
+const shelfTableName = `shelves-${currentTestName}`;
+const schemaName = "default";
+
+// Join source for the relation target's @Joined label.
+@RegisterTable(authorTableName, schemaName)
+class Author extends Table {
+  declare _id: string;
+  declare name: string;
+}
+class AuthorModel extends BasicDataModel(Author, authorTableName) {}
+
+// Relation TARGET: `authorName` is a @Joined field (not a physical column),
+// pulled from Author via authorId — like memberSettingDataAPI.name from User.
+@RegisterTable(bookTableName, schemaName)
+class Book extends Table {
+  declare _id: string;
+  declare authorId: string;
+  declare title: string;
+}
+class BookModel extends BasicDataModel(Book, bookTableName) {}
+
+// PARENT (the listed controller): `book` is a relation to Book, whose label is
+// the joined `authorName`.
+@RegisterTable(shelfTableName, schemaName)
+class Shelf extends Table {
+  declare _id: string;
+  declare book: string; // stores a Book._id
+}
+class ShelfModel extends BasicDataModel(Shelf, shelfTableName) {}
+
+interface ShelfListed {
+  _id: string;
+  book: {
+    _id: string;
+    title: string;
+    authorId: string;
+    authorName: string | null;
+  } | null;
+}
+
+const orphanBookId = "orphan-book-id";
+
+describe("Foreign relation with @Joined target label", () => {
+  it("resolves a joined label through a relation in list", async () =>
+    await resolvesJoinedLabelInList());
+  it("returns null relation for an orphan foreign key", async () =>
+    await returnsNullForOrphanRelation());
+  it("resolves a joined label through a relation in get", async () =>
+    await resolvesJoinedLabelInGet());
+});
+
+async function _setup(testName: string) {
+  @RegisterDataController()
+  class _BookTargetAPI extends DataController(
+    Book,
+    { list: DefaultRoutes.List },
+    Controller(`/${testName}_book`),
+  ) {
+    @ModelReference()
+    @Model(BookModel)
+    declare bookModel: BookModel;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare _id: string;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare authorId: string;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare title: string;
+
+    @Listable(["authorId"])
+    @Joined({
+      table: authorTableName,
+      localKey: "authorId",
+      remoteField: "name",
+    })
+    declare authorName: string;
+  }
+
+  const bookMeta = GetMetadata(_BookTargetAPI, DataAPIMeta);
+
+  @RegisterDataController()
+  class _ShelfAPI extends DataController(
+    Shelf,
+    { list: DefaultRoutes.List, get: DefaultRoutes.Get },
+    Controller(`/${testName}`),
+  ) {
+    @ModelReference()
+    @Model(ShelfModel)
+    declare shelfModel: ShelfModel;
+
+    @Listable()
+    @Access(AccessMode.ReadOnly)
+    declare _id: string;
+
+    @Listable()
+    @Foreign(
+      bookTableName,
+      undefined,
+      false,
+      ["_id", "title", "authorName"],
+      undefined,
+      bookMeta,
+    )
+    @Access(AccessMode.ReadWrite)
+    declare book: string;
+  }
+
+  await RegisterSchema(schemaName);
+  await _dropTables();
+
+  const schemaInstance = getSchemaInstance(schemaName);
+  const authorModel = new AuthorModel(schemaInstance);
+  const bookModel = new BookModel(schemaInstance);
+  const shelfModel = new ShelfModel(schemaInstance);
+
+  const authorIdsRecord = await authorModel.insert([
+    { name: "Alice Carter" },
+    { name: "Bob Stone" },
+  ]);
+  const authorIds = Object.values(authorIdsRecord);
+
+  const bookIdsRecord = await bookModel.insert([
+    { authorId: authorIds[0], title: "Alpha Rising" },
+    { authorId: authorIds[1], title: "Beta Stories" },
+  ]);
+  const bookIds = Object.values(bookIdsRecord);
+
+  const shelfIdsRecord = await shelfModel.insert([
+    { book: bookIds[0] },
+    { book: bookIds[1] },
+    { book: orphanBookId },
+  ]);
+  const shelfIds = Object.values(shelfIdsRecord);
+
+  return { authorIds, bookIds, shelfIds };
+}
+
+async function _dropTables() {
+  const schema = Schema.get(schemaName);
+  if (schema) {
+    await schema.instance().table(shelfTableName).delete();
+    await schema.instance().table(bookTableName).delete();
+    await schema.instance().table(authorTableName).delete();
+  }
+}
+
+async function resolvesJoinedLabelInList() {
+  await _setup(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {});
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: ShelfListed[] };
+
+  const alpha = data.results.find((s) => s.book?.title === "Alpha Rising");
+  expect(alpha, "row for Alpha Rising").to.not.equal(undefined);
+  // Core regression: the joined label resolves through the relation.
+  expect(alpha?.book?.authorName).to.equal("Alice Carter");
+
+  const beta = data.results.find((s) => s.book?.title === "Beta Stories");
+  expect(beta?.book?.authorName).to.equal("Bob Stone");
+}
+
+async function returnsNullForOrphanRelation() {
+  await _setup(getFunctionName());
+
+  const response = await listRequest(getFunctionName(), {});
+  expect(response.status).to.equal(200);
+  const data = (await response.json()) as { results: ShelfListed[] };
+
+  // The orphan shelf points to a non-existent book → relation stays null.
+  const titles = data.results.map((s) => s.book?.title);
+  expect(titles).to.include("Alpha Rising");
+  const orphan = data.results.find(
+    (s) => s.book === null || s.book?.title === undefined,
+  );
+  expect(orphan, "orphan relation row present").to.not.equal(undefined);
+  expect(orphan?.book?.authorName ?? null).to.equal(null);
+}
+
+async function resolvesJoinedLabelInGet() {
+  const { shelfIds } = await _setup(getFunctionName());
+
+  const response = await getRequest(getFunctionName(), { id: shelfIds[0] });
+  if (response.status !== 200) {
+    const text = await response.text();
+    throw new Error(`get failed (${response.status}): ${text}`);
+  }
+  const shelf = (await response.json()) as ShelfListed;
+  expect(shelf.book?.title).to.equal("Alpha Rising");
+  expect(shelf.book?.authorName).to.equal("Alice Carter");
+}


### PR DESCRIPTION
## What

Fixes #14 — a relation (`Foreign`) whose label (`keyMapping`) points at a `@Joined`
field on the target controller came back **empty** in `list`/`get`, while the
same field resolves fine when the target is fetched through its own route.

## Root cause

`Query.Foreign` resolved a relation against the **raw** target table and plucked
the requested fields:

```ts
const other = resolveSchemaDb(db, schemaName).table(table);
query = query.lookup(other.pluck("_internal", ...pluckField) as Table<any>, name, index || "_id");
```

A `@Joined` field is not a physical column — it is materialized by `Query.Joined`,
which is only ever applied to the target's *own* query, never to this sub-lookup.
So a joined label resolved to nothing. The `Datum` (get) branch had the same gap.

## Fix

- **`metadata.ts`** — the `Foreign` decorator / `setForeign` now accept an optional
  `targetMeta` (the target's `DataAPIMeta`). When given, the target's relevant
  `@Joined` fields (those present in `pluck`) are captured into `field.foreign`
  as `ForeignJoinedRef[]`, and their `localKey` is added to the pluck so the join
  key is fetched. Fully backward compatible: without `targetMeta`, behaviour is
  unchanged.
- **`components.ts`** — `Query.Foreign` re-materializes those joined fields after
  the lookup, in both the `Stream` (list) and `Datum` (get) paths, mirroring the
  hoist→lookup→merge approach of `Query.Joined`. Orphan foreign keys still resolve
  to `null`.

This is the framework half of a two-part fix: a downstream consumer that builds
relations via `Foreign` (e.g. a `RelationType` whose target exposes a joined
label) passes the target meta to opt in. The non-`_id` join `index` was **not**
the cause and keeps working.

## Tests

New `src/tests/components/foreign_joined.test.ts` (target whose `name` label is a
`@Joined` from another table, referenced through a relation):

- resolves the joined label through a relation in **list** ✅ (the reported bug)
- resolves the joined label through a relation in **get** ✅
- returns `null` for an **orphan** foreign key ✅

Full suite green locally (`72 passing`), lint and build clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where a `@Foreign` relation whose pluck included a `@Joined` field on the target controller would return that field empty, because the plain table lookup never materialized virtual/joined columns. The fix threads the target's `DataAPIMeta` into `setForeign`, captures the relevant `@Joined` descriptors as `ForeignJoinedRef[]`, and re-materializes them at query time via a second lookup in both the stream (list) and datum (get) paths.

- **`metadata.ts`**: `setForeign` now accepts an optional `targetMeta`; joined fields present in the requested pluck are captured into `foreign[6]`, with their `localKey` kept out of `foreign[4]` to prevent leaking join keys into the API response.
- **`components.ts`**: `Query.Foreign` extends the lookup pluck with join keys at query time, calls new `applyForeignJoinedStream`/`applyForeignJoinedDatum` helpers, and `Validation.ClearInternal` gains orphan-detection logic to normalize a joined-but-unmatched object back to `null`.
- **`foreign_joined.test.ts`**: New test suite covering list, get, and orphan scenarios in both paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is strictly additive: without targetMeta the behaviour is identical to before, and new code paths are exercised only when opt-in metadata is supplied.

The happy-path logic for both stream and datum paths is sound and well-tested across list, get, and orphan scenarios. The two findings are narrow edge cases that do not affect the bug being fixed or any currently tested configuration.

The orphan-normalization branch in src/components.ts (ClearInternal, lines 919-931) is worth a second look for the all-joined-pluck edge case. The ShelfListed interface in the test file should be corrected to match the actual response shape.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/metadata.ts | Adds ForeignJoinedRef interface and extends setForeign/Foreign decorator with optional targetMeta to capture target @Joined fields at decoration time. Logic is correct: joined fields present in the pluck are collected into targetJoined, their localKey is intentionally excluded from foreign[4] to avoid leaking join keys in the API response. |
| src/components.ts | Adds applyForeignJoinedStream and applyForeignJoinedDatum helpers and wires them into Query.Foreign; extends Validation.ClearInternal with orphan detection logic. Stream and datum paths for the happy path look correct; minor gap in orphan normalization when all pluck fields are joined fields. |
| src/tests/components/foreign_joined.test.ts | New test covering list, get, and orphan cases for the fixed bug. Assertions are thorough; minor issue: the ShelfListed TypeScript interface includes authorId which the test itself asserts is absent from the response. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant QF as Query.Foreign
    participant Lookup1 as DB lookup book table
    participant FJS as applyForeignJoinedStream
    participant Lookup2 as DB lookup author table
    participant CI as Validation.ClearInternal

    Client->>QF: list shelves
    QF->>Lookup1: lookup book pluck _id title authorId
    Lookup1-->>QF: stream with book _id title authorId
    QF->>FJS: applyForeignJoinedStream for authorName
    FJS->>FJS: map hoist book.authorId into tmpKey
    FJS->>Lookup2: lookup author table by tmpKey
    Lookup2-->>FJS: author row resolved
    FJS->>FJS: map merge authorName then remove tmpKey
    FJS-->>QF: stream with book _id title authorId authorName
    QF-->>CI: raw results
    CI->>CI: orphan check physicalKeys all null returns null
    CI->>CI: pluck to _id title authorName strips authorId
    CI-->>Client: results with book _id title authorName
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant QF as Query.Foreign
    participant Lookup1 as DB lookup book table
    participant FJS as applyForeignJoinedStream
    participant Lookup2 as DB lookup author table
    participant CI as Validation.ClearInternal

    Client->>QF: list shelves
    QF->>Lookup1: lookup book pluck _id title authorId
    Lookup1-->>QF: stream with book _id title authorId
    QF->>FJS: applyForeignJoinedStream for authorName
    FJS->>FJS: map hoist book.authorId into tmpKey
    FJS->>Lookup2: lookup author table by tmpKey
    Lookup2-->>FJS: author row resolved
    FJS->>FJS: map merge authorName then remove tmpKey
    FJS-->>QF: stream with book _id title authorId authorName
    QF-->>CI: raw results
    CI->>CI: orphan check physicalKeys all null returns null
    CI->>CI: pluck to _id title authorName strips authorId
    CI-->>Client: results with book _id title authorName
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: address review — no join-key leak, ..."](https://github.com/antelopejs/interface-data-api/commit/a1c6f54718d736942ecf60a053333074c46fa974) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39013753)</sub>

<!-- /greptile_comment -->